### PR TITLE
Fix the Stripe webhook and amount_raised

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+log: tail -f log/development.log

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -31,7 +31,7 @@ module ExceptionHandler
 
     # Invalid signature
     rescue_from Stripe::SignatureVerificationError do |e|
-      json_response({ message: e.error.message }, e.http_status)
+      json_response({ message: e.message }, e.http_status)
     end
 
   end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,14 +1,13 @@
 class WebhooksController < ApplicationController
   # POST /webhooks
   def create
-    payload = request.body.read
-    event = nil
+    Stripe.api_key = ENV['STRIPE_API_KEY']
 
     # Verify webhook signature and extract the event
     # See https://stripe.com/docs/webhooks/signatures for more information.
     sig_header = request.env['HTTP_STRIPE_SIGNATURE']
-
     endpoint_secret = ENV['STRIPE_WEBHOOK_KEY']
+    payload = request.body.read
 
     event = Stripe::Webhook.construct_event(
       payload, sig_header, endpoint_secret

--- a/app/helpers/sellers_helper.rb
+++ b/app/helpers/sellers_helper.rb
@@ -3,10 +3,12 @@ module SellersHelper
     locations = seller.locations
     seller = seller.as_json
     seller['locations'] = locations.as_json
-    seller['amount_raised'] = SellersHelper.calculate_amount_raised(seller_id: seller['seller_id'])
+    seller['amount_raised'] = SellersHelper.calculate_amount_raised(seller_id: seller['id'])
     seller
   end
 
+  # Calculates the amount of money raised by the Seller so far.
+  # seller_id: the actual id of the Seller. Seller.id
   def self.calculate_amount_raised(seller_id:)
     return 0 if Item.where(seller_id: seller_id).empty?
 

--- a/spec/factories/seller.rb
+++ b/spec/factories/seller.rb
@@ -1,7 +1,7 @@
 
 FactoryBot.define do
   factory :seller do
-    seller_id { Faker::Lorem.word }
+    seller_id { Faker::Alphanumeric.alphanumeric(number: 64) }
     cuisine_name { Faker::Food.dish }
     name { Faker::Movies::StarWars.planet }
     story { Faker::Movies::StarWars.wookiee_sentence }

--- a/spec/helpers/sellers_helper_spec.rb
+++ b/spec/helpers/sellers_helper_spec.rb
@@ -1,9 +1,82 @@
 require 'rails_helper'
 
 RSpec.describe SellersHelper, type: :helper do
+  let(:seller) { create :seller }
+
+  describe 'generate_seller_json' do
+    let(:expected_seller) do
+      {
+        'id': seller.id,
+        'seller_id': seller.seller_id,
+        'cuisine_name': seller.cuisine_name,
+        'name': seller.name,
+        'story': seller.story,
+        'accept_donations': seller.accept_donations,
+        'sell_gift_cards': seller.sell_gift_cards,
+        'owner_name': seller.owner_name,
+        'owner_image_url': seller.owner_image_url,
+        'created_at': seller.created_at,
+        'updated_at': seller.updated_at,
+        'target_amount': seller.target_amount,
+        'summary': seller.summary,
+        'locations': []
+      }.as_json
+    end
+
+    context 'with no money raised' do
+      it 'returns the list of sellers with `and`' do
+        expected_seller['amount_raised'] = 0
+        expect(SellersHelper.generate_seller_json(seller: seller))
+          .to eq(expected_seller)
+      end
+    end
+
+    context 'with money raised' do
+      before do
+        # Create $50 gift card
+        item_gift_card1 = create(:item, seller: seller)
+        gift_card_detail1 = create(:gift_card_detail, item: item_gift_card1)
+        create(
+          :gift_card_amount,
+          value: 50_00,
+          gift_card_detail: gift_card_detail1
+        )
+
+        # Create second gift card, which is a $50 gift card with $20 spent
+        item_gift_card2 = create(:item, seller: seller)
+        gift_card_detail2 = create(:gift_card_detail, item: item_gift_card2)
+        create(
+          :gift_card_amount,
+          value: 50_00,
+          gift_card_detail: gift_card_detail2
+        )
+        # Updated a day later
+        create(
+          :gift_card_amount,
+          value: 30_00,
+          gift_card_detail: gift_card_detail2,
+          updated_at: Time.current + 1.day
+        )
+
+        # Create a donation of $200
+        item_donation1 = create(:item, seller: seller)
+        create(:donation_detail, item: item_donation1, amount: 200_00)
+
+        # Create a donation of $10
+        item_donation2 = create(:item, seller: seller)
+        create(:donation_detail, item: item_donation2, amount: 10_00)
+      end
+
+      it 'returns the list of sellers with `and`' do
+        expected_seller['amount_raised'] = 290_00
+        expect(SellersHelper.generate_seller_json(seller: seller))
+          .to eq(expected_seller)
+      end
+    end
+  end
+
   describe '#calculate_amount_raised' do
-    let(:seller) { create :seller }
-    context.skip 'with no money raised' do
+    context 'with no money raised' do
 
       it 'returns the list of sellers with `and`' do
         expect(SellersHelper.calculate_amount_raised(seller_id: seller.id)).to eq(0)


### PR DESCRIPTION
The Stripe webhook was broken because it wasn't
the Stripe API key for header verification.

Also, amount_raised was broken because I was
using the wrong seller_id. I was passing in
Seller.seller_id when I should have been
using Seller.id. I added an integration test
to cover this.

Finally I updated the factory for Seller because
using a single "word" was causing a lot of
collisions in the test db.