### PR TITLE
Surface Square Payments Errors to API

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -123,6 +123,13 @@ class ChargesController < ApplicationController
     }
 
     api_response = api_client.payments.create_payment(body: request_body)
+
+    errors = api_response.errors
+    raise SquarePaymentsError.new(
+      errors: errors,
+      status_code: api_response.status_code
+    ) if errors.present?
+
     payment = api_response.data.payment
 
     # Creates a pending PaymentIntent. See webhooks_controller to see what happens

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -4,6 +4,17 @@ module ExceptionHandler
   class InvalidGiftCardUpdate < StandardError; end
   class CannotGenerateUniqueHash < StandardError; end
   class InvalidSquareSignature < StandardError; end
+  class SquarePaymentsError < StandardError
+    attr_reader :status_code
+    attr_reader :errors
+
+    def initialize(errors:, status_code:)
+      @status_code = status_code
+      @errors = errors
+      # Get the first error and give the detail of it as a message
+      super("#{errors.first[:detail]}")
+    end
+  end
 
   # provides the more graceful `included` method
   extend ActiveSupport::Concern
@@ -33,6 +44,15 @@ module ExceptionHandler
     # Invalid signature
     rescue_from InvalidSquareSignature do |e|
       json_response({ message: e.message }, e.http_status)
+    end
+
+    rescue_from SquarePaymentsError do |e|
+      json_response({
+        # Give the detail of the first error
+        message: e.message,
+        type: 'SQUARE_PAYMENTS_ERROR',
+        errors: e.errors
+        }, e.status_code)
     end
   end
 end

--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -60,6 +60,78 @@ RSpec.describe 'Charges API', type: :request do
           ]
         end
 
+        describe 'with error codes' do
+          context 'with bad CVV' do
+            # Test value taken from https://developer.squareup.com/docs/testing/test-values
+            let(:nonce) { 'cnon:card-nonce-rejected-cvv' }
+
+            it 'returns status code 400' do
+              expect(response).to have_http_status(400)
+            end
+
+            it 'returns a validation failure message' do
+              expect(response.body)
+                .to match(/CVV_FAILURE/)
+            end
+          end
+
+          context 'with bad postal code' do
+            # Test value taken from https://developer.squareup.com/docs/testing/test-values
+            let(:nonce) { 'cnon:card-nonce-rejected-postalcode' }
+
+            it 'returns status code 400' do
+              expect(response).to have_http_status(400)
+            end
+
+            it 'returns a validation failure message' do
+              expect(response.body)
+                .to match(/ADDRESS_VERIFICATION_FAILURE/)
+            end
+          end
+
+          context 'with bad expiration date' do
+            # Test value taken from https://developer.squareup.com/docs/testing/test-values
+            let(:nonce) { 'cnon:card-nonce-rejected-expiration' }
+
+            it 'returns status code 400' do
+              expect(response).to have_http_status(400)
+            end
+
+            it 'returns a validation failure message' do
+              expect(response.body)
+                .to match(/INVALID_EXPIRATION/)
+            end
+          end
+
+          context 'with card declined' do
+            # Test value taken from https://developer.squareup.com/docs/testing/test-values
+            let(:nonce) { 'cnon:card-nonce-declined' }
+
+            it 'returns status code 400' do
+              expect(response).to have_http_status(400)
+            end
+
+            it 'returns a validation failure message' do
+              expect(response.body)
+                .to match(/GENERIC_DECLINE/)
+            end
+          end
+
+          context 'with card nonce already used' do
+            # Test value taken from https://developer.squareup.com/docs/testing/test-values
+            let(:nonce) { 'cnon:card-nonce-rejected-cvv' }
+
+            it 'returns status code 400' do
+              expect(response).to have_http_status(400)
+            end
+
+            it 'returns a validation failure message' do
+              expect(response.body)
+                .to match(/CVV_FAILURE/)
+            end
+          end
+        end
+
         before { post '/charges', params: params, as: :json }
 
         it 'returns Square Payment' do


### PR DESCRIPTION
Errors weren't being caught in the Square
Payment Flow. Created a new Square Error
object that is serialized for the frontend
to consume.