### PR TITLE
Add email_text col to PaymentIntents table

### DIFF
--- a/db/migrate/20200423234913_add_email_text_to_payment_intents.rb
+++ b/db/migrate/20200423234913_add_email_text_to_payment_intents.rb
@@ -1,0 +1,5 @@
+class AddEmailTextToPaymentIntents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :payment_intents, :email_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_18_203010) do
+ActiveRecord::Schema.define(version: 2020_04_23_234913) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2020_04_18_203010) do
     t.boolean "successful", default: false
     t.string "square_payment_id"
     t.string "square_location_id"
+    t.string "email_text"
   end
 
   create_table "sellers", force: :cascade do |t|


### PR DESCRIPTION
Store the generated note from the charge in PaymentIntents so it can eventually be passed through to the email receipt