### PR TITLE
Add vendor/bundle to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 # Ignore intellij stuff
 .idea/
 ruby.iml
+
+# Ignore install to vendor folder
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://gorails.com/setup/ubuntu/19.10
 1. Download rails, gem install rails — brew install gem
 2. brew install postgresql
 3. Install heroku cli
-4. bundle install
+4. bundle install --path vendor/bundle
 5. rails db:create
 6. rails db:migrate
 7. heroku local web -> localhost:5000


### PR DESCRIPTION
Does anyone know why the default `bundle install` not install it into vendor/bundle even though there is a config file listed in the project directory?