### PR TITLE
Move seller_id to the charges api body instead of per line_item

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -1,48 +1,51 @@
+# frozen_string_literal: true
+
 require 'securerandom'
 
 class ChargesController < ApplicationController
-
   # POST /charges
   def create
     line_items = charge_params[:line_items].map(&:to_h)
 
     seller_id = charge_params[:seller_id]
 
+    validate(seller_id: seller_id, line_items: line_items)
+
     # Validate each Item and get all ItemTypes
     item_types = Set.new
-    line_items.each do |item|
-      validate(seller_id: seller_id, line_item: item)
-      item_types.add item['item_type']
-    end
+    line_items.each { |item| item_types.add item['item_type'] }
 
     seller = Seller.find_by(seller_id: seller_id)
 
     # Total all Items
-    amount = line_items.inject(0) { |sum, item| sum + item['amount'] * item['quantity'] }
+    amount =
+      line_items.inject(0) do |sum, item|
+        sum + item['amount'] * item['quantity']
+      end
 
-    description = generate_description(
-      seller_name: seller.name,
-      item_types: item_types
-    )
+    description =
+      generate_description(seller_name: seller.name, item_types: item_types)
 
     email = charge_params[:email]
-    if charge_params[:is_square]
-      payment = create_square_payment_request(
-        source_id: charge_params[:nonce],
-        amount: amount,
-        note: description,
-        email: email,
-        name: charge_params[:name],
-        seller: seller,
-        line_items: line_items,
+    payment =
+      if charge_params[:is_square]
+        create_square_payment_request(
+          source_id: charge_params[:nonce],
+          amount: amount,
+          note: description,
+          email: email,
+          name: charge_params[:name],
+          seller: seller,
+          line_items: line_items
         )
-    else
-      payment = create_stripe_payment_request(
-        amount: amount,
-        email: email,
-        description: description,
-        line_items: line_items)
-    end
+      else
+        create_stripe_payment_request(
+          amount: amount,
+          email: email,
+          description: description,
+          line_items: line_items
+        )
+      end
 
     json_response(payment)
   end
@@ -56,67 +59,74 @@ class ChargesController < ApplicationController
     params.require(:is_square)
     params.require(:nonce) if params[:is_square]
     params.require(:name)
-    params.permit(:email, :nonce, :is_square, :name, :seller_id, line_items: [[:amount, :currency, :item_type, :quantity]])
+    params.permit(
+      :email,
+      :nonce,
+      :is_square,
+      :name,
+      :seller_id,
+      line_items: [%i[amount currency item_type quantity]]
+    )
   end
 
-  def validate(seller_id:, line_item:)
-    [:amount, :currency, :item_type, :quantity].each do |attribute|
-      unless line_item.key?(attribute)
-        raise ActionController::ParameterMissing.new "param is missing or the value is empty: #{attribute}"
+  def validate(seller_id:, line_items:)
+    unless Seller.find_by(seller_id: seller_id).present?
+      raise InvalidLineItem, "Seller does not exist: #{seller_id}"
+    end
+
+    line_items.each do |line_item|
+      %i[amount currency item_type quantity].each do |attribute|
+        unless line_item.key?(attribute)
+          raise ActionController::ParameterMissing,
+                "param is missing or the value is empty: #{attribute}"
+        end
+      end
+
+      unless %w[gift_card donation].include? line_item['item_type']
+        raise InvalidLineItem,
+              'line_item must be named `gift_card` or `donation`'
+      end
+
+      unless line_item['amount'].is_a? Integer
+        raise InvalidLineItem, 'line_item.amount must be an Integer'
+      end
+
+      unless line_item['quantity'].is_a? Integer
+        raise InvalidLineItem, 'line_item.quantity must be an Integer'
+      end
+
+      amount = line_item['amount']
+      unless amount >= 50
+        raise InvalidLineItem, 'Amount must be at least $0.50 usd'
       end
     end
-
-    unless ['gift_card', 'donation'].include? line_item['item_type']
-      raise InvalidLineItem.new 'line_item must be named `gift_card` or `donation`'
-    end
-
-    unless Seller.find_by(seller_id: seller_id).present?
-      raise InvalidLineItem.new "Seller does not exist: #{seller_id}"
-    end
-
-    unless line_item['amount'].is_a? Integer
-      raise InvalidLineItem.new 'line_item.amount must be an Integer'
-    end
-
-    unless line_item['quantity'].is_a? Integer
-      raise InvalidLineItem.new 'line_item.quantity must be an Integer'
-    end
-
-    amount = line_item['amount']
-    raise InvalidLineItem.new 'Amount must be at least $0.50 usd' unless amount >= 50
   end
 
   def generate_description(seller_name:, item_types:)
     description = 'Thank you for supporting ' + seller_name + '.'
     if item_types.include? 'gift_card'
-      description += ' Your gift card(s) will be emailed to you when the seller opens back up.'
+      description +=
+        ' Your gift card(s) will be emailed to you when the seller opens back up.'
     end
 
     description
   end
 
-  def create_square_payment_request(source_id:, amount:, note:, email:, name:, seller:, line_items:)
-    api_client = Square::Client.new(
-      access_token: ENV['SQUARE_ACCESS_TOKEN'],
-      environment: if Rails.env.production? then 'production' else 'sandbox' end
-    )
+  def create_square_payment_request(
+    source_id:, amount:, note:, email:, name:, seller:, line_items:
+  )
+    api_client =
+      Square::Client.new(
+        access_token: ENV['SQUARE_ACCESS_TOKEN'],
+        environment: Rails.env.production? ? 'production' : 'sandbox'
+      )
 
-    # Default location in prod:
-    # https://squareup.com/dashboard/locations/3D0QAW4CSZJWZ
-    # In the future we might associate a Square location with each seller that we onboard
-    # This will give us access into reporting for each merchant.
-    # The reason why I'm not doing this work right now is because you can only associate
-    # one location per charge, but we might want to allow for people to add multiple gift
-    # cards into their card for diffrent Sellers, and then check out all at once.
     square_location_id = seller.square_location_id
 
     request_body = {
       source_id: source_id,
       idempotency_key: SecureRandom.uuid,
-      amount_money: {
-        amount: amount,
-        currency: 'USD',
-      },
+      amount_money: { amount: amount, currency: 'USD' },
       buyer_email_address: email,
       note: note,
       location_id: square_location_id
@@ -125,10 +135,11 @@ class ChargesController < ApplicationController
     api_response = api_client.payments.create_payment(body: request_body)
 
     errors = api_response.errors
-    raise SquarePaymentsError.new(
-      errors: errors,
-      status_code: api_response.status_code
-    ) if errors.present?
+    if errors.present?
+      raise SquarePaymentsError.new(
+        errors: errors, status_code: api_response.status_code
+      )
+    end
 
     payment = api_response.data.payment
     receipt_url = payment[:receipt_url]
@@ -141,7 +152,7 @@ class ChargesController < ApplicationController
       email: email,
       line_items: line_items.to_json,
       receipt_url: receipt_url,
-      name: name,
+      name: name
     )
 
     api_response
@@ -150,20 +161,19 @@ class ChargesController < ApplicationController
   def create_stripe_payment_request(amount:, email:, description:, line_items:)
     Stripe.api_key = ENV['STRIPE_API_KEY']
 
-    intent = Stripe::PaymentIntent.create(
-      amount: amount,
-      currency: 'usd',
-      receipt_email: email,
-      payment_method_types: ['card'],
-      description: description
-    )
+    intent =
+      Stripe::PaymentIntent.create(
+        amount: amount,
+        currency: 'usd',
+        receipt_email: email,
+        payment_method_types: %w[card],
+        description: description
+      )
 
     # Creates a pending PaymentIntent. See webhooks_controller to see what happens
     # when the PaymentIntent is successful.
     PaymentIntent.create!(
-      stripe_id: intent['id'],
-      email: email,
-      line_items: line_items.to_json
+      stripe_id: intent['id'], email: email, line_items: line_items.to_json
     )
 
     intent

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -13,15 +13,17 @@ class ChargesController < ApplicationController
 
     # Validate each Item and get all ItemTypes
     item_types = Set.new
-    line_items.each { |item| item_types.add item['item_type'] }
+    line_items.each do |item|
+      item_types.add item['item_type']
+      item[:seller_id] = seller_id
+    end
 
     seller = Seller.find_by(seller_id: seller_id)
 
     # Total all Items
-    amount =
-      line_items.inject(0) do |sum, item|
-        sum + item['amount'] * item['quantity']
-      end
+    amount = line_items.inject(0) do |sum, item|
+      sum + item['amount'] * item['quantity']
+    end
 
     description =
       generate_description(seller_name: seller.name, item_types: item_types)

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -10,6 +10,8 @@ class WebhooksController < ApplicationController
     json_response({})
   end
 
+  private
+
   def handle_stripe_event
     Stripe.api_key = ENV['STRIPE_API_KEY']
 

--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe 'Charges API', type: :request do
@@ -6,22 +8,30 @@ RSpec.describe 'Charges API', type: :request do
     let(:email) { 'mrkrabs@thekrustykrab.com' }
     let(:nonce) { nil }
     let(:is_square) { false }
-    let(:name) { 'Squarepants, Spongebob'}
-    let(:params) { { email: email, is_square: is_square, nonce: nonce, line_items: line_items, name: name } }
+    let(:name) { 'Squarepants, Spongebob' }
     let(:seller_id) { 'shunfa-bakery' }
-    let!(:seller) { create(:seller, seller_id: seller_id, name: 'Shunfa Bakery') }
+    let(:params) do
+      {
+        email: email,
+        is_square: is_square,
+        nonce: nonce,
+        line_items: line_items,
+        seller_id: seller_id,
+        name: name
+      }
+    end
+    let!(:seller) do
+      create(
+        :seller,
+        seller_id: seller_id,
+        square_location_id: 'E4R1NCMHG7B2Y',
+        name: 'Shunfa Bakery'
+      )
+    end
 
     context 'with a gift card' do
       let(:line_items) do
-        [
-          {
-            amount: 50,
-            currency: 'usd',
-            item_type: 'gift_card',
-            quantity: 1,
-            seller_id: seller_id
-          }
-        ]
+        [{ amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1 }]
       end
 
       before { post '/charges', params: params, as: :json }
@@ -32,10 +42,9 @@ RSpec.describe 'Charges API', type: :request do
         expect(json['currency']).to eq('usd')
         expect(json['receipt_email']).to eq(email)
 
-        expect(PaymentIntent.find_by(
-                 email: email,
-                 line_items: line_items.to_json
-        )).not_to be_nil
+        expect(
+          PaymentIntent.find_by(email: email, line_items: line_items.to_json)
+        ).not_to be_nil
       end
 
       it 'returns status code 200' do
@@ -50,15 +59,7 @@ RSpec.describe 'Charges API', type: :request do
 
       context 'with a gift card' do
         let(:line_items) do
-          [
-            {
-              amount: 50,
-              currency: 'usd',
-              item_type: 'gift_card',
-              quantity: 1,
-              seller_id: seller_id
-            }
-          ]
+          [{ amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1 }]
         end
 
         describe 'with error codes' do
@@ -71,8 +72,7 @@ RSpec.describe 'Charges API', type: :request do
             end
 
             it 'returns a validation failure message' do
-              expect(response.body)
-                .to match(/CVV_FAILURE/)
+              expect(response.body).to match(/CVV_FAILURE/)
             end
           end
 
@@ -85,8 +85,7 @@ RSpec.describe 'Charges API', type: :request do
             end
 
             it 'returns a validation failure message' do
-              expect(response.body)
-                .to match(/ADDRESS_VERIFICATION_FAILURE/)
+              expect(response.body).to match(/ADDRESS_VERIFICATION_FAILURE/)
             end
           end
 
@@ -99,8 +98,7 @@ RSpec.describe 'Charges API', type: :request do
             end
 
             it 'returns a validation failure message' do
-              expect(response.body)
-                .to match(/INVALID_EXPIRATION/)
+              expect(response.body).to match(/INVALID_EXPIRATION/)
             end
           end
 
@@ -113,8 +111,7 @@ RSpec.describe 'Charges API', type: :request do
             end
 
             it 'returns a validation failure message' do
-              expect(response.body)
-                .to match(/GENERIC_DECLINE/)
+              expect(response.body).to match(/GENERIC_DECLINE/)
             end
           end
 
@@ -127,8 +124,7 @@ RSpec.describe 'Charges API', type: :request do
             end
 
             it 'returns a validation failure message' do
-              expect(response.body)
-                .to match(/CVV_FAILURE/)
+              expect(response.body).to match(/CVV_FAILURE/)
             end
           end
         end
@@ -142,10 +138,9 @@ RSpec.describe 'Charges API', type: :request do
           expect(payment['amount_money']['currency']).to eq('USD')
           expect(payment['buyer_email_address']).to eq(email)
 
-          expect(PaymentIntent.find_by(
-                   email: email,
-                   line_items: line_items.to_json
-          )).not_to be_nil
+          expect(
+            PaymentIntent.find_by(email: email, line_items: line_items.to_json)
+          ).not_to be_nil
         end
 
         it 'returns status code 200' do
@@ -157,18 +152,10 @@ RSpec.describe 'Charges API', type: :request do
         let(:line_items) do
           [
             {
-              amount: 5000,
-              currency: 'usd',
-              item_type: 'gift_card',
-              quantity: 1,
-              seller_id: seller_id
+              amount: 5000, currency: 'usd', item_type: 'gift_card', quantity: 1
             },
             {
-              amount: 3000,
-              currency: 'usd',
-              item_type: 'donation',
-              quantity: 1,
-              seller_id: seller_id
+              amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1
             }
           ]
         end
@@ -182,10 +169,9 @@ RSpec.describe 'Charges API', type: :request do
           expect(payment['amount_money']['currency']).to eq('USD')
           expect(payment['buyer_email_address']).to eq(email)
 
-          expect(PaymentIntent.find_by(
-                   email: email,
-                   line_items: line_items.to_json
-          )).not_to be_nil
+          expect(
+            PaymentIntent.find_by(email: email, line_items: line_items.to_json)
+          ).not_to be_nil
         end
 
         it 'returns status code 200' do
@@ -196,14 +182,7 @@ RSpec.describe 'Charges API', type: :request do
 
     context 'with line item with missing amount' do
       let(:line_items) do
-        [
-          {
-            currency: 'usd',
-            item_type: 'gift_card',
-            quantity: 1,
-            seller_id: seller_id
-          }
-        ]
+        [{ currency: 'usd', item_type: 'gift_card', quantity: 1 }]
       end
 
       before { post '/charges', params: params, as: :json }
@@ -213,22 +192,14 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: amount/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: amount/
+        )
       end
     end
 
     context 'with line item with missing currency' do
-      let(:line_items) do
-        [
-          {
-            amount: 50,
-            item_type: 'gift_card',
-            quantity: 1,
-            seller_id: seller_id
-          }
-        ]
-      end
+      let(:line_items) { [{ amount: 50, item_type: 'gift_card', quantity: 1 }] }
 
       before { post '/charges', params: params, as: :json }
 
@@ -237,21 +208,15 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: currency/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: currency/
+        )
       end
     end
 
     context 'with line item with missing item_type' do
       let(:line_items) do
-        [
-          {
-            amount: 50,
-            currency: 'usd',
-            quantity: 1,
-            seller_id: seller_id
-          }
-        ]
+        [{ amount: 50, currency: 'usd', quantity: 1, seller_id: seller_id }]
       end
 
       before { post '/charges', params: params, as: :json }
@@ -261,8 +226,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: item_type/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: item_type/
+        )
       end
     end
 
@@ -285,32 +251,31 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: quantity/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: quantity/
+        )
       end
     end
 
-    context 'with line item with missing seller_id' do
+    context 'with charge with missing seller_id' do
       let(:line_items) do
-        [
-          {
-            amount: 50,
-            currency: 'usd',
-            item_type: 'gift_card',
-            quantity: 1
-          }
-        ]
+        [{ amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1 }]
       end
 
-      before { post '/charges', params: params, as: :json }
+      before do
+        post '/charges',
+             params: { email: 'Foobar@foo.com', line_items: line_items },
+             as: :json
+      end
 
       it 'returns status code 422' do
         expect(response).to have_http_status(422)
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: seller_id/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: seller_id/
+        )
       end
     end
 
@@ -334,8 +299,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/line_item must be named `gift_card` or `donation`/)
+        expect(response.body).to match(
+          /line_item must be named `gift_card` or `donation`/
+        )
       end
     end
 
@@ -359,8 +325,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match('{"message":"Amount must be at least $0.50 usd"}')
+        expect(response.body).to match(
+          '{"message":"Amount must be at least $0.50 usd"}'
+        )
       end
     end
 
@@ -384,8 +351,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match('{"message":"Amount must be at least $0.50 usd"}')
+        expect(response.body).to match(
+          '{"message":"Amount must be at least $0.50 usd"}'
+        )
       end
     end
 
@@ -409,20 +377,21 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match('line_item.amount must be an Integer')
+        expect(response.body).to match('line_item.amount must be an Integer')
       end
     end
 
     context 'with float amount' do
       let(:line_items) do
-        [{
-          amount: 50.5,
-          currency: 'usd',
-          item_type: 'gift_card',
-          quantity: 1,
-          seller_id: seller_id
-        }]
+        [
+          {
+            amount: 50.5,
+            currency: 'usd',
+            item_type: 'gift_card',
+            quantity: 1,
+            seller_id: seller_id
+          }
+        ]
       end
 
       before { post '/charges', params: params, as: :json }
@@ -432,8 +401,7 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match('line_item.amount must be an Integer')
+        expect(response.body).to match('line_item.amount must be an Integer')
       end
     end
 
@@ -441,19 +409,9 @@ RSpec.describe 'Charges API', type: :request do
       let(:line_items) do
         [
           {
-            amount: 5000,
-            currency: 'usd',
-            item_type: 'gift_card',
-            quantity: 1,
-            seller_id: seller_id
+            amount: 5000, currency: 'usd', item_type: 'gift_card', quantity: 1
           },
-          {
-            amount: 3000,
-            currency: 'usd',
-            item_type: 'donation',
-            quantity: 1,
-            seller_id: seller_id
-          }
+          { amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1 }
         ]
       end
 
@@ -465,10 +423,9 @@ RSpec.describe 'Charges API', type: :request do
         expect(json['currency']).to eq('usd')
         expect(json['receipt_email']).to eq(email)
 
-        expect(PaymentIntent.find_by(
-                 email: email,
-                 line_items: line_items.to_json
-        )).not_to be_nil
+        expect(
+          PaymentIntent.find_by(email: email, line_items: line_items.to_json)
+        ).not_to be_nil
       end
 
       it 'returns status code 200' do
@@ -481,16 +438,13 @@ RSpec.describe 'Charges API', type: :request do
         post(
           '/charges',
           params: {
+            seller_id: seller_id,
             line_items: [
               {
-                amount: 50,
-                currency: 'usd',
-                item_type: 'gift_card',
-                quantity: 1,
-                seller_id: seller_id
+                amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1
               }
             ],
-            name: "Jane Doe"
+            name: 'Jane Doe'
           },
           as: :json
         )
@@ -501,8 +455,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: email/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: email/
+        )
       end
     end
 
@@ -514,8 +469,9 @@ RSpec.describe 'Charges API', type: :request do
       end
 
       it 'returns a validation failure message' do
-        expect(response.body)
-          .to match(/param is missing or the value is empty: line_items/)
+        expect(response.body).to match(
+          /param is missing or the value is empty: seller_id/
+        )
       end
     end
 
@@ -543,63 +499,46 @@ RSpec.describe 'Charges API', type: :request do
         end
 
         it 'should include gift card details' do
-          thank_you = "Thank you for supporting #{seller.name}, and #{seller2.name}."
-          expect(Stripe::PaymentIntent).to receive(:create)
-            .with(
-              amount: 13100,
-              currency: 'usd',
-              payment_method_types: ['card'],
-              receipt_email: email,
-              description: thank_you + ' Your gift card(s) will be emailed to you when the seller opens back up.'
-            )
-            .and_call_original
+          thank_you = "Thank you for supporting #{seller.name}."
+          expect(Stripe::PaymentIntent).to receive(:create).with(
+            amount: 13_100,
+            currency: 'usd',
+            payment_method_types: %w[card],
+            receipt_email: email,
+            description:
+              thank_you +
+                ' Your gift card(s) will be emailed to you when the seller opens back up.'
+          ).and_call_original
 
           post '/charges', params: params, as: :json
         end
       end
 
       context 'when donations only' do
-        let!(:seller2) { create(:seller, name: 'Apple Bakery') }
-        let!(:seller3) { create(:seller, name: 'Zebra Stripes') }
-
         let(:line_items) do
           [
             {
-              amount: 5050,
-              currency: 'usd',
-              item_type: 'donation',
-              quantity: 2,
-              seller_id: seller.seller_id
+              amount: 5050, currency: 'usd', item_type: 'donation', quantity: 2
             },
             {
-              amount: 3000,
-              currency: 'usd',
-              item_type: 'donation',
-              quantity: 1,
-              seller_id: seller2.seller_id
+              amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1
             },
             {
-              amount: 3000,
-              currency: 'usd',
-              item_type: 'donation',
-              quantity: 1,
-              seller_id: seller3.seller_id
+              amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1
             }
           ]
         end
 
         before { post '/charges', params: params, as: :json }
         it 'should not include gift card details' do
-          thank_you = "Thank you for supporting #{seller2.name}, #{seller.name}, and #{seller3.name}."
-          expect(Stripe::PaymentIntent).to receive(:create)
-            .with(
-              amount: 16100,
-              currency: 'usd',
-              receipt_email: email,
-              payment_method_types: ['card'],
-              description: thank_you
-            )
-            .and_call_original
+          thank_you = "Thank you for supporting #{seller.name}."
+          expect(Stripe::PaymentIntent).to receive(:create).with(
+            amount: 16_100,
+            currency: 'usd',
+            receipt_email: email,
+            payment_method_types: %w[card],
+            description: thank_you
+          ).and_call_original
 
           post '/charges', params: params, as: :json
         end

--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -31,7 +31,15 @@ RSpec.describe 'Charges API', type: :request do
 
     context 'with a gift card' do
       let(:line_items) do
-        [{ amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1 }]
+        [
+          {
+            amount: 50,
+            currency: 'usd',
+            item_type: 'gift_card',
+            quantity: 1,
+            seller_id: seller_id
+          }
+        ]
       end
 
       before { post '/charges', params: params, as: :json }
@@ -59,7 +67,15 @@ RSpec.describe 'Charges API', type: :request do
 
       context 'with a gift card' do
         let(:line_items) do
-          [{ amount: 50, currency: 'usd', item_type: 'gift_card', quantity: 1 }]
+          [
+            {
+              amount: 50,
+              currency: 'usd',
+              item_type: 'gift_card',
+              quantity: 1,
+              seller_id: seller_id
+            }
+          ]
         end
 
         describe 'with error codes' do
@@ -152,10 +168,18 @@ RSpec.describe 'Charges API', type: :request do
         let(:line_items) do
           [
             {
-              amount: 5000, currency: 'usd', item_type: 'gift_card', quantity: 1
+              amount: 5000,
+              currency: 'usd',
+              item_type: 'gift_card',
+              quantity: 1,
+              seller_id: seller_id
             },
             {
-              amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1
+              amount: 3000,
+              currency: 'usd',
+              item_type: 'donation',
+              quantity: 1,
+              seller_id: seller_id
             }
           ]
         end
@@ -409,9 +433,19 @@ RSpec.describe 'Charges API', type: :request do
       let(:line_items) do
         [
           {
-            amount: 5000, currency: 'usd', item_type: 'gift_card', quantity: 1
+            amount: 5000,
+            currency: 'usd',
+            item_type: 'gift_card',
+            quantity: 1,
+            seller_id: seller_id
           },
-          { amount: 3000, currency: 'usd', item_type: 'donation', quantity: 1 }
+          {
+            amount: 3000,
+            currency: 'usd',
+            item_type: 'donation',
+            quantity: 1,
+            seller_id: seller_id
+          }
         ]
       end
 


### PR DESCRIPTION
Make the seller_id to the body of the api instead of per line item so that we can use that to reference the square_location_id 