### PR TITLE
Use pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 4.0.0'
   gem 'faker'
-  gem 'pry', '~> 0.12.2'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -239,7 +242,7 @@ DEPENDENCIES
   faker
   listen (>= 3.0.5, < 3.2)
   pg
-  pry (~> 0.12.2)
+  pry-byebug
   puma (~> 4.1)
   rack-cors
   rails (~> 6.0.2, >= 6.0.2.2)


### PR DESCRIPTION
Adds `step`, `next`, `finish` and `continue` commands and breakpoints to Pry using byebug.

To use, invoke pry normally. No need to start your script or app differently.

```
def some_method
  binding.pry          # Execution will stop here.
  puts 'Hello World'   # Run 'step' or 'next' in the console to move here.
end
```

https://www.rubydoc.info/gems/pry-byebug/2.0.0