### PR TITLE
Implemented server-side charge dedup

### DIFF
--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -5,6 +5,7 @@ module ExceptionHandler
   class InvalidGiftCardUpdate < StandardError; end
   class CannotGenerateUniqueHash < StandardError; end
   class InvalidSquareSignature < StandardError; end
+  class DuplicateChargeError < StandardError; end
   class DuplicatePaymentCompletedError < StandardError; end
   class SquarePaymentsError < StandardError
     attr_reader :status_code
@@ -38,7 +39,12 @@ module ExceptionHandler
       json_response({ message: e.error.message }, :bad_request)
     end
 
-    rescue_from DuplicatePaymentCompletedError do |e|
+    rescue_from Stripe::StripeError do |e|
+      json_response({ message: e.error.message }, e.http_status)
+    end
+
+    rescue_from DuplicateChargeError,
+                DuplicatePaymentCompletedError do |e|
       json_response({ message: e.message }, :bad_request)
     end
 

--- a/app/models/existing_event.rb
+++ b/app/models/existing_event.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ExistingEvent < ApplicationRecord
-  validates_presence_of :idempotency_key, :type
+  validates_presence_of :idempotency_key, :event_type
   validates_uniqueness_of :idempotency_key
-  enum type: %i[charges_create webhooks_create_refund_updated]
+  enum event_type: %i[charges_create webhooks_create_refund_updated]
 end

--- a/db/migrate/20200502030458_rename_existing_event_column.rb
+++ b/db/migrate/20200502030458_rename_existing_event_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameExistingEventColumn < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :existing_events, :type, :event_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_05_02_062150) do
 
   create_table "existing_events", force: :cascade do |t|
     t.string "idempotency_key"
-    t.integer "type"
+    t.integer "event_type"
   end
 
   create_table "gift_card_amounts", force: :cascade do |t|

--- a/spec/models/existing_event_spec.rb
+++ b/spec/models/existing_event_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ExistingEvent, type: :model do
   it { should validate_presence_of(:idempotency_key) }
   it { should validate_uniqueness_of(:idempotency_key) }
   it do
-    should define_enum_for(:type).with(
+    should define_enum_for(:event_type).with(
       %i[charges_create webhooks_create_refund_updated]
     )
   end


### PR DESCRIPTION
1. Rename `type` column in `existing_events` table to `item_type` because `type` is a reserved keyword in ActiveRecord https://stackoverflow.com/questions/17879024/activerecordsubclassnotfound-the-single-table-inheritance-mechanism-failed-to

2. Return an error if there is a charge request with the same `idempotency_key` as a previous charge. This should be rare now that we have client-side deduplication

Test plan:
Verified HTTP response for duplicate charge
<img width="657" alt="Screen Shot 2020-05-01 at 11 41 10 PM" src="https://user-images.githubusercontent.com/2313868/80854488-ce79c280-8c06-11ea-8282-8723bd3f8af6.png">
