### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -108,7 +108,6 @@ RSpec.describe 'Webhooks API', type: :request do
         let(:item_type) { 'donation' }
 
         it 'creates pool donation and rounds' do
-
           expect(DonationDetail.count).to eq(2)
           expect(Item.count).to eq(2)
           expect(PaymentIntent.count).to eq(1)

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -108,12 +108,6 @@ RSpec.describe 'Webhooks API', type: :request do
         let(:item_type) { 'donation' }
 
         it 'creates pool donation and rounds' do
-          puts "###############ddd#######"
-          Seller.all.each do |dd|
-            puts dd.seller_id
-            puts dd.accept_donations
-          end
-          puts "###############dd#######"
 
           expect(DonationDetail.count).to eq(2)
           expect(Item.count).to eq(2)
@@ -143,204 +137,204 @@ RSpec.describe 'Webhooks API', type: :request do
         end
       end
     end
-#
-#     context 'with donation' do
-#       let(:amount) { 5000 }
-#       let(:item_type) { 'donation' }
-#       let(:seller_id) { seller1.seller_id }
-#
-#       it 'creates a donation' do
-#         donation_detail = DonationDetail.last
-#         expect(donation_detail).not_to be_nil
-#         expect(donation_detail['amount']).to eq(5000)
-#
-#         item = Item.find(donation_detail['item_id'])
-#         expect(item).not_to be_nil
-#         expect(item.purchaser).to eq(payment_intent.purchaser)
-#         expect(item.donation?).to be true
-#         expect(item.seller).to eq(seller1)
-#
-#         payment_intent = PaymentIntent.find(item['payment_intent_id'])
-#         expect(payment_intent.successful).to be true
-#       end
-#
-#       it 'returns status code 200' do
-#         expect(response).to have_http_status(200)
-#       end
-#
-#       context 'with refund' do
-#         let(:refund_response) do
-#           {
-#             'refund': {
-#               'id': SecureRandom.uuid,
-#               'payment_id': payment_intent.square_payment_id,
-#               'status': status
-#             }
-#           }
-#         end
-#
-#         let(:refund_payload) do
-#           {
-#             'event_id': 'dfgh-4567',
-#             'type': payload_type,
-#             'data': {
-#               'object': refund_response
-#             }
-#           }
-#         end
-#
-#         before do
-#           post(
-#             '/webhooks',
-#             headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-#             params: refund_payload.to_json
-#           )
-#         end
-#
-#         context 'refund.created' do
-#           let(:payload_type) { 'refund.created' }
-#           let(:status) { 'PENDING' }
-#
-#           it 'creates a refund' do
-#             refund = Refund.last
-#
-#             expect(refund).not_to be_nil
-#             expect(refund.status).to eq(status)
-#             expect(refund.square_refund_id).to eq(
-#               refund_response[:refund][:id]
-#             )
-#             expect(refund.payment_intent_id).to eq(payment_intent.id)
-#           end
-#
-#           context 'refund.updated' do
-#             before do
-#               post(
-#                 '/webhooks',
-#                 headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-#                 params: {
-#                   'event_id': 'hjkl-1234',
-#                   'type': 'refund.updated',
-#                   'data': {
-#                     'object': {
-#                       'refund': {
-#                         'id': SecureRandom.uuid,
-#                         'payment_id': payment_intent.square_payment_id,
-#                         'status': updated_status
-#                       }
-#                     }
-#                   }
-#                 }.to_json
-#               )
-#             end
-#
-#             context 'COMPLETED' do
-#               let(:updated_status) { 'COMPLETED' }
-#
-#               it 'updates the status' do
-#                 refund = Refund.last
-#
-#                 expect(refund).not_to be_nil
-#                 expect(refund.status).to eq(updated_status)
-#               end
-#
-#               it 'refunds all of the items' do
-#                 Refund.last.payment_intent.items.all do |item|
-#                   expect(item.refunded).to eq(true)
-#                 end
-#               end
-#             end
-#
-#             context 'FAILED' do
-#               let(:updated_status) { 'FAILED' }
-#
-#               it 'updates the status' do
-#                 refund = Refund.last
-#
-#                 expect(refund).not_to be_nil
-#                 expect(refund.status).to eq(updated_status)
-#               end
-#
-#               it "doesn't refund all of the items" do
-#                 Refund.last.payment_intent.items.all do |item|
-#                   expect(item.refunded).to eq(false)
-#                 end
-#               end
-#             end
-#           end
-#         end
-#       end
-#
-#       context 'with duplicate call' do
-#         before do
-#           post(
-#             '/webhooks',
-#             headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-#             params: payload.to_json
-#           )
-#         end
-#
-#         it 'returns status code 400' do
-#           expect(response.body)
-#             .to match(
-#               /Request was already received/
-#             )
-#
-#           expect(response).to have_http_status(409)
-#         end
-#       end
-#     end
-#
-#     context 'with gift card' do
-#       let(:amount) { 5000 }
-#       let(:item_type) { 'gift_card' }
-#       let(:seller_id) { seller1.seller_id }
-#
-#       it 'creates a gift card' do
-#         gift_card_detail = GiftCardDetail.last
-#         expect(gift_card_detail).not_to be_nil
-#         expect(gift_card_detail.gift_card_id).to eq(
-#           'aweofijn-3n3400-oawjiefwef-0iawef-0i'
-#         )
-#         expect(gift_card_detail.seller_gift_card_id).to eq('#ABC-DE')
-#         expect(gift_card_detail.expiration).to eq(Date.today + 1.year)
-#
-#         gift_card_amount = GiftCardAmount.find_by(
-#           gift_card_detail_id: gift_card_detail['id']
-#         )
-#         expect(gift_card_amount['value']).to eq(5000)
-#
-#         item = Item.find(gift_card_detail['item_id'])
-#         expect(item).not_to be_nil
-#         expect(item.gift_card?).to be true
-#         expect(item.seller).to eq(seller1)
-#         expect(item.purchaser).to eq(payment_intent.purchaser)
-#
-#         payment_intent = PaymentIntent.find(item['payment_intent_id'])
-#         expect(payment_intent.successful).to be true
-#       end
-#
-#       it 'returns status code 200' do
-#         expect(response).to have_http_status(200)
-#       end
-#
-#       context 'with duplicate call' do
-#         before do
-#           post(
-#             '/webhooks',
-#             headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-#             params: payload.to_json
-#           )
-#         end
-#
-#         it 'returns status code 400' do
-#           expect(response.body)
-#             .to match(
-#               /Request was already received/
-#             )
-#
-#           expect(response).to have_http_status(409)
-#         end
-#       end
-#     end
+
+    context 'with donation' do
+      let(:amount) { 5000 }
+      let(:item_type) { 'donation' }
+      let(:seller_id) { seller1.seller_id }
+
+      it 'creates a donation' do
+        donation_detail = DonationDetail.last
+        expect(donation_detail).not_to be_nil
+        expect(donation_detail['amount']).to eq(5000)
+
+        item = Item.find(donation_detail['item_id'])
+        expect(item).not_to be_nil
+        expect(item.purchaser).to eq(payment_intent.purchaser)
+        expect(item.donation?).to be true
+        expect(item.seller).to eq(seller1)
+
+        payment_intent = PaymentIntent.find(item['payment_intent_id'])
+        expect(payment_intent.successful).to be true
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      context 'with refund' do
+        let(:refund_response) do
+          {
+            'refund': {
+              'id': SecureRandom.uuid,
+              'payment_id': payment_intent.square_payment_id,
+              'status': status
+            }
+          }
+        end
+
+        let(:refund_payload) do
+          {
+            'event_id': 'dfgh-4567',
+            'type': payload_type,
+            'data': {
+              'object': refund_response
+            }
+          }
+        end
+
+        before do
+          post(
+            '/webhooks',
+            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+            params: refund_payload.to_json
+          )
+        end
+
+        context 'refund.created' do
+          let(:payload_type) { 'refund.created' }
+          let(:status) { 'PENDING' }
+
+          it 'creates a refund' do
+            refund = Refund.last
+
+            expect(refund).not_to be_nil
+            expect(refund.status).to eq(status)
+            expect(refund.square_refund_id).to eq(
+              refund_response[:refund][:id]
+            )
+            expect(refund.payment_intent_id).to eq(payment_intent.id)
+          end
+
+          context 'refund.updated' do
+            before do
+              post(
+                '/webhooks',
+                headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+                params: {
+                  'event_id': 'hjkl-1234',
+                  'type': 'refund.updated',
+                  'data': {
+                    'object': {
+                      'refund': {
+                        'id': SecureRandom.uuid,
+                        'payment_id': payment_intent.square_payment_id,
+                        'status': updated_status
+                      }
+                    }
+                  }
+                }.to_json
+              )
+            end
+
+            context 'COMPLETED' do
+              let(:updated_status) { 'COMPLETED' }
+
+              it 'updates the status' do
+                refund = Refund.last
+
+                expect(refund).not_to be_nil
+                expect(refund.status).to eq(updated_status)
+              end
+
+              it 'refunds all of the items' do
+                Refund.last.payment_intent.items.all do |item|
+                  expect(item.refunded).to eq(true)
+                end
+              end
+            end
+
+            context 'FAILED' do
+              let(:updated_status) { 'FAILED' }
+
+              it 'updates the status' do
+                refund = Refund.last
+
+                expect(refund).not_to be_nil
+                expect(refund.status).to eq(updated_status)
+              end
+
+              it "doesn't refund all of the items" do
+                Refund.last.payment_intent.items.all do |item|
+                  expect(item.refunded).to eq(false)
+                end
+              end
+            end
+          end
+        end
+      end
+
+      context 'with duplicate call' do
+        before do
+          post(
+            '/webhooks',
+            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+            params: payload.to_json
+          )
+        end
+
+        it 'returns status code 400' do
+          expect(response.body)
+            .to match(
+              /Request was already received/
+            )
+
+          expect(response).to have_http_status(409)
+        end
+      end
+    end
+
+    context 'with gift card' do
+      let(:amount) { 5000 }
+      let(:item_type) { 'gift_card' }
+      let(:seller_id) { seller1.seller_id }
+
+      it 'creates a gift card' do
+        gift_card_detail = GiftCardDetail.last
+        expect(gift_card_detail).not_to be_nil
+        expect(gift_card_detail.gift_card_id).to eq(
+          'aweofijn-3n3400-oawjiefwef-0iawef-0i'
+        )
+        expect(gift_card_detail.seller_gift_card_id).to eq('#ABC-DE')
+        expect(gift_card_detail.expiration).to eq(Date.today + 1.year)
+
+        gift_card_amount = GiftCardAmount.find_by(
+          gift_card_detail_id: gift_card_detail['id']
+        )
+        expect(gift_card_amount['value']).to eq(5000)
+
+        item = Item.find(gift_card_detail['item_id'])
+        expect(item).not_to be_nil
+        expect(item.gift_card?).to be true
+        expect(item.seller).to eq(seller1)
+        expect(item.purchaser).to eq(payment_intent.purchaser)
+
+        payment_intent = PaymentIntent.find(item['payment_intent_id'])
+        expect(payment_intent.successful).to be true
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+
+      context 'with duplicate call' do
+        before do
+          post(
+            '/webhooks',
+            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+            params: payload.to_json
+          )
+        end
+
+        it 'returns status code 400' do
+          expect(response.body)
+            .to match(
+              /Request was already received/
+            )
+
+          expect(response).to have_http_status(409)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Explicitly attach the payment intent to the relevant seller to not create random spurious sellers while creating the payment intent's contact objects