### PR TITLE
Add `is_distribution` flag to charges request

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -32,9 +32,7 @@ class ChargesController < ApplicationController
         sum + item['amount'] * item['quantity']
       end
 
-    is_distribution = !charge_params[:is_distribution].nil? ?
-      charge_params[:is_distribution] :
-      false
+    is_distribution = charge_params[:is_distribution] || false
 
     email = charge_params[:email]
     payment = create_square_payment_request(nonce: charge_params[:nonce],

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -72,6 +72,7 @@ class ChargesController < ApplicationController
       :name,
       :seller_id,
       :idempotency_key,
+      :is_subscribed,
       :is_distribution,
       line_items: [%i[amount currency item_type quantity]]
     )

--- a/spec/models/existing_event_spec.rb
+++ b/spec/models/existing_event_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ExistingEvent, type: :model do
   it { should validate_presence_of(:idempotency_key) }
   it { should validate_uniqueness_of(:idempotency_key).scoped_to(:event_type) }
   it do
-    should define_enum_for(:event_type).with(
+    should define_enum_for(:event_type).with_values(
       %i[
         charges_create
         payment_updated

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -16,7 +16,13 @@ RSpec.describe 'Webhooks API', type: :request do
         'seller_id': seller_id
       }].to_json
     end
-    let(:contact) do
+    let(:purchaser) do
+      create(
+        :contact,
+        seller: Seller.find_by(seller_id: seller_id)
+      )
+    end
+    let(:recipient) do
       create(
         :contact,
         seller: Seller.find_by(seller_id: seller_id)
@@ -27,8 +33,8 @@ RSpec.describe 'Webhooks API', type: :request do
         :payment_intent,
         square_payment_id: SecureRandom.uuid,
         square_location_id: SecureRandom.uuid,
-        recipient: contact,
-        purchaser: contact,
+        recipient: recipient,
+        purchaser: purchaser,
         line_items: line_items
       )
     end
@@ -306,10 +312,12 @@ RSpec.describe 'Webhooks API', type: :request do
         expect(item).not_to be_nil
         expect(item.gift_card?).to be true
         expect(item.seller).to eq(seller1)
-        expect(item.purchaser).to eq(payment_intent.purchaser)
 
         payment_intent = PaymentIntent.find(item['payment_intent_id'])
         expect(payment_intent.successful).to be true
+        expect(payment_intent.recipient).not_to eq(payment_intent.purchaser)
+        expect(item.purchaser).to eq(payment_intent.purchaser)
+        expect(gift_card_detail.recipient).to eq(payment_intent.recipient)
       end
 
       it 'returns status code 200' do


### PR DESCRIPTION
Added `is_distribution` flag to charges api to determine if we should query `Seller` to fetch the `distributor` and assign that as the `recipient` instead of the `purchaser`.