### PR TITLE
Removed email and items from payment_intents and items

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -294,7 +294,7 @@ class WebhooksController < ApplicationController
            '<p> the Send Chinatown Love team</p>' \
            '</body>' \
            '</html>'
-    send_receipt(to: payment_intent.email, html: html)
+    send_receipt(to: payment_intent.recipient.email, html: html)
   end
 
   def send_donation_receipt(payment_intent:, amount:, merchant:)
@@ -314,7 +314,7 @@ class WebhooksController < ApplicationController
            '<p> the Send Chinatown Love team</p>' \
            '</body>' \
            '</html>'
-    send_receipt(to: payment_intent.email, html: html)
+    send_receipt(to: payment_intent.recipient.email, html: html)
   end
 
   def send_gift_card_receipt(payment_intent:, amount:, merchant:, receipt_id:)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,6 @@
 # Table name: items
 #
 #  id                :bigint           not null, primary key
-#  email             :string
 #  item_type         :integer
 #  refunded          :boolean          default(FALSE)
 #  created_at        :datetime         not null

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -5,10 +5,7 @@
 # Table name: payment_intents
 #
 #  id                 :bigint           not null, primary key
-#  email              :string
-#  email_text         :string
 #  line_items         :text
-#  name               :string
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null

--- a/db/migrate/20200516190635_remove_name_and_email_from_payment_intent.rb
+++ b/db/migrate/20200516190635_remove_name_and_email_from_payment_intent.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveNameAndEmailFromPaymentIntent < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :payment_intents, :email, :string
+    remove_column :payment_intents, :email_text, :string
+    remove_column :payment_intents, :name, :string
+  end
+end

--- a/db/migrate/20200516191859_remove_email_from_item.rb
+++ b/db/migrate/20200516191859_remove_email_from_item.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveEmailFromItem < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :items, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_163901) do
+ActiveRecord::Schema.define(version: 2020_05_16_190635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,16 +98,13 @@ ActiveRecord::Schema.define(version: 2020_05_13_163901) do
   end
 
   create_table "payment_intents", force: :cascade do |t|
-    t.string "email"
     t.text "line_items"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "successful", default: false
     t.string "square_payment_id", null: false
     t.string "square_location_id", null: false
-    t.string "email_text"
     t.string "receipt_url"
-    t.string "name"
     t.bigint "purchaser_id"
     t.bigint "recipient_id"
     t.index ["purchaser_id"], name: "index_payment_intents_on_purchaser_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_190635) do
+ActiveRecord::Schema.define(version: 2020_05_16_191859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 2020_05_16_190635) do
   end
 
   create_table "items", force: :cascade do |t|
-    t.string "email"
     t.bigint "seller_id", null: false
     t.integer "item_type"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :item do
-    email { Faker::Internet.email }
     association :seller
     association :payment_intent
     association :purchaser, factory: :contact

--- a/spec/factories/payment_intent.rb
+++ b/spec/factories/payment_intent.rb
@@ -2,10 +2,7 @@
 
 FactoryBot.define do
   factory :payment_intent do
-    email { Faker::Internet.email }
     receipt_url { Faker::Lorem.word }
-    name { Faker::Superhero.name }
-    email_text { Faker::Superhero.power }
     successful { false }
     square_payment_id { Faker::Alphanumeric.alphanumeric(number: 64) }
     square_location_id { Faker::Alphanumeric.alphanumeric(number: 64) }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,7 +5,6 @@
 # Table name: items
 #
 #  id                :bigint           not null, primary key
-#  email             :string
 #  item_type         :integer
 #  refunded          :boolean          default(FALSE)
 #  created_at        :datetime         not null

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -5,10 +5,7 @@
 # Table name: payment_intents
 #
 #  id                 :bigint           not null, primary key
-#  email              :string
-#  email_text         :string
 #  line_items         :text
-#  name               :string
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Webhooks API', type: :request do
         'payment': {
           'id': payment_intent.square_payment_id,
           'location_id': payment_intent.square_location_id,
-          'receipt_email': payment_intent.email,
+          'receipt_email': payment_intent.recipient.email,
           'status': 'COMPLETED'
         }
       }


### PR DESCRIPTION
We also had used `email` in our `webhooks` which was changed to `payment_intent.recipient.email`.