### PR TITLE
Distribute the remaining cents between merchants

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -130,7 +130,8 @@ class WebhooksController < ApplicationController
         # calculate amount per merchant
         # This will break if we ever have zero merchants but are still
         # accepting pool donations.
-        amount_per = (amount.to_f / @donation_sellers.count.to_f).ceil
+        amount_per = (amount.to_f / @donation_sellers.count.to_f).floor
+        remainder = amount % @donation_sellers.count
 
         @donation_sellers.each do |seller|
           next if seller.seller_id.eql?(Seller::POOL_DONATION_SELLER_ID)
@@ -139,8 +140,9 @@ class WebhooksController < ApplicationController
             seller_id: seller.seller_id,
             purchaser: purchaser,
             payment_intent: payment_intent,
-            amount: amount_per
+            amount: amount_per + (remainder > 0 ? 1 : 0)
           )
+          remainder -= 1
         end
         begin
           send_pool_donation_receipt(

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -35,6 +35,7 @@ class Seller < ApplicationRecord
   # The `seller_id` of the special seller we use to collect pool donations.
   POOL_DONATION_SELLER_ID = 'send-chinatown-love'
 
+  # NOTE: POOL_DONATION_SELLER_ID does not accept donations
   scope :filter_by_accepts_donations, -> { where(accept_donations: true) }
 
   translates :name, :story, :owner_name, :summary, :business_type


### PR DESCRIPTION
When calculating how much to pay each merchant,
we can't divide cents. We were previously rounding
up. However, that will cause us to have accounting
errors when trying to do things like "figure out how
much fees we paid Square" or when we want to know
how much money we comped for fees to the merchant.

Therefore we added some logic to distribute the
remaining cents.