### PR TITLE
Add eager_load and cache_classes to staging.rb

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -4,13 +4,14 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in
   # config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  # Code is not reloaded between requests.
+  config.cache_classes = true
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
   # Configure CORS
   config.middleware.insert_before 0, Rack::Cors do


### PR DESCRIPTION
This is to ensure that environments are loaded up similarly to how it's
loaded up in production. Eager loading breaks if the modules are not
named properly and rails throws an exception