### PR TITLE
Add sorting to sellers controller.

### DIFF
--- a/app/controllers/sellers_controller.rb
+++ b/app/controllers/sellers_controller.rb
@@ -5,7 +5,15 @@ class SellersController < ApplicationController
 
   # GET /sellers
   def index
-    @sellers = Seller.all
+
+    query = Validate::GetSellersQuery.new(params)
+
+    unless query.valid?
+      raise InvalidParameterError, query.errors.full_messages.to_sentence
+    end
+
+    @sellers = Seller.order("#{query.sort_key} #{query.sort_order}")
+
     sellers = @sellers.map do |seller|
       SellersHelper.generate_seller_json(
         seller: seller

--- a/app/controllers/validate/get_sellers_query.rb
+++ b/app/controllers/validate/get_sellers_query.rb
@@ -15,8 +15,8 @@ module Validate
         @sort_key = 'created_at'
         @sort_order  = 'desc'
       else
-        @sort_key = params[:sort].split('.')[0]
-        @sort_order = params[:sort].split('.')[1] || 'desc'
+        @sort_key = params[:sort].split(':')[0]
+        @sort_order = params[:sort].split(':')[1] || 'desc'
       end
     end
   end

--- a/app/controllers/validate/get_sellers_query.rb
+++ b/app/controllers/validate/get_sellers_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Validate
+  class GetSellersQuery
+    include ActiveModel::Validations
+
+    attr_accessor :sort_key, :sort_order
+
+    validates :sort_key, presence: true, inclusion: { in: %w[created_at] }
+    validates :sort_order, presence: true, inclusion: { in: %w[desc asc] }
+
+    def initialize(params = {})
+      if params[:sort].nil?
+        # Default to most recent sellers
+        @sort_key = 'created_at'
+        @sort_order  = 'desc'
+      else
+        @sort_key = params[:sort].split('.')[0]
+        @sort_order = params[:sort].split('.')[1] || 'desc'
+      end
+    end
+  end
+end

--- a/spec/controllers/validate/get_sellers_query_spec.rb
+++ b/spec/controllers/validate/get_sellers_query_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Need to specify type since we're using ActiveModel::Validations
+describe Validate::GetSellersQuery, '#valid?', type: :model do
+  it 'is valid query with empty params' do
+    query = Validate::GetSellersQuery.new({})
+    expect(query.valid?).to eq(true)
+    expect(query.sort_key).to eq('created_at')
+    expect(query.sort_order).to eq('desc')
+  end
+
+  it 'is valid query with only sort key' do
+    query = Validate::GetSellersQuery.new({sort: 'created_at'})
+    expect(query.valid?).to eq(true)
+    expect(query.sort_key).to eq('created_at')
+    expect(query.sort_order).to eq('desc')
+  end
+
+  it 'is valid query with both sort key and order desc' do
+    query = Validate::GetSellersQuery.new({sort: 'created_at.desc'})
+    expect(query.valid?).to eq(true)
+    expect(query.sort_key).to eq('created_at')
+    expect(query.sort_order).to eq('desc')
+  end
+
+  it 'is valid query with both sort key and order asc' do
+    query = Validate::GetSellersQuery.new({sort: 'created_at.asc'})
+    expect(query.valid?).to eq(true)
+    expect(query.sort_key).to eq('created_at')
+    expect(query.sort_order).to eq('asc')
+  end
+
+  it 'is not valid query with empty string' do
+    query = Validate::GetSellersQuery.new({sort: ''})
+    expect(query.valid?).to eq(false)
+  end
+
+  it 'is not valid query with wrong sort key' do
+    query = Validate::GetSellersQuery.new({sort: 'foo'})
+    expect(query.valid?).to eq(false)
+  end
+
+  it 'is not valid query with wrong sort key and order' do
+    query = Validate::GetSellersQuery.new({sort: 'foo.bar'})
+    expect(query.valid?).to eq(false)
+  end
+end

--- a/spec/controllers/validate/get_sellers_query_spec.rb
+++ b/spec/controllers/validate/get_sellers_query_spec.rb
@@ -19,14 +19,14 @@ describe Validate::GetSellersQuery, '#valid?', type: :model do
   end
 
   it 'is valid query with both sort key and order desc' do
-    query = Validate::GetSellersQuery.new({sort: 'created_at.desc'})
+    query = Validate::GetSellersQuery.new({sort: 'created_at:desc'})
     expect(query.valid?).to eq(true)
     expect(query.sort_key).to eq('created_at')
     expect(query.sort_order).to eq('desc')
   end
 
   it 'is valid query with both sort key and order asc' do
-    query = Validate::GetSellersQuery.new({sort: 'created_at.asc'})
+    query = Validate::GetSellersQuery.new({sort: 'created_at:asc'})
     expect(query.valid?).to eq(true)
     expect(query.sort_key).to eq('created_at')
     expect(query.sort_order).to eq('asc')

--- a/spec/requests/sellers_spec.rb
+++ b/spec/requests/sellers_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'Sellers API', type: :request do
   # initialize test data
-  before { freeze_time }
-  let(:current_time) { Time.current.utc.iso8601(3).to_s }
   let(:seller_id1) { seller1.seller_id }
   let!(:seller1) do
     create(:seller)
@@ -47,6 +45,42 @@ RSpec.describe 'Sellers API', type: :request do
       # Note `json` is a custom helper to parse JSON responses
       expect(json).not_to be_empty
       expect(json.size).to eq(2)
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  # Test suite for GET /sellers
+  describe 'GET /sellers sort by created_at asc' do
+    # make HTTP get request before each example
+    before { get '/sellers?sort=created_at.asc' }
+
+    it 'returns sellers' do
+      # Note `json` is a custom helper to parse JSON responses
+      expect(json).not_to be_empty
+      expect(json.size).to eq(2)
+      expect(json[0]['id']).to eq(seller1.id)
+      expect(json[1]['id']).to eq(seller2.id)
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  # Test suite for GET /sellers
+  describe 'GET /sellers sort by created_at desc' do
+    # make HTTP get request before each example
+    before { get '/sellers?sort=created_at.desc' }
+
+    it 'returns sellers' do
+      # Note `json` is a custom helper to parse JSON responses
+      expect(json).not_to be_empty
+      expect(json.size).to eq(2)
+      expect(json[0]['id']).to eq(seller2.id)
+      expect(json[1]['id']).to eq(seller1.id)
     end
 
     it 'returns status code 200' do

--- a/spec/requests/sellers_spec.rb
+++ b/spec/requests/sellers_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Sellers API', type: :request do
   # Test suite for GET /sellers
   describe 'GET /sellers sort by created_at asc' do
     # make HTTP get request before each example
-    before { get '/sellers?sort=created_at.asc' }
+    before { get '/sellers?sort=created_at:asc' }
 
     it 'returns sellers' do
       # Note `json` is a custom helper to parse JSON responses
@@ -73,7 +73,7 @@ RSpec.describe 'Sellers API', type: :request do
   # Test suite for GET /sellers
   describe 'GET /sellers sort by created_at desc' do
     # make HTTP get request before each example
-    before { get '/sellers?sort=created_at.desc' }
+    before { get '/sellers?sort=created_at:desc' }
 
     it 'returns sellers' do
       # Note `json` is a custom helper to parse JSON responses


### PR DESCRIPTION
Resolves #136 

Since we want to not only sort by `created_at`, added `{key}:{order}` so that we could sort by the specified key and order. Defaults the sort order to `created_at:desc`

Followed this guide
* https://www.moesif.com/blog/technical/api-design/REST-API-Design-Filtering-Sorting-and-Pagination/#sorting
* https://jsao.io/2018/08/creating-a-rest-api-manual-pagination-sorting-and-filtering/
* https://specs.openstack.org/openstack/api-wg/guidelines/pagination_filter_sort.html#sorting