### PR TITLE
Email receipts for gift a meal

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -35,7 +35,6 @@ class ChargesController < ApplicationController
         sum + item['amount'] * item['quantity']
       end
 
-
     email = charge_params[:email]
     payment = create_square_payment_request(nonce: charge_params[:nonce],
                                             amount: amount,

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -132,9 +132,7 @@ class WebhooksController < ApplicationController
         #                 all in an N log N sort—which is horrible. Ideally,
         #                 we would memoize amount_raised, and fix the N+1 query
         #                 in GiftCardDetail that calculates amount.
-        @donation_sellers = Seller.filter_by_accepts_donations.sort_by do |s|
-          s.amount_raised
-        end
+        @donation_sellers = Seller.filter_by_accepts_donations.sort_by(&:amount_raised)
 
         # calculate amount per merchant
         # This will break if we ever have zero merchants but are still
@@ -153,10 +151,10 @@ class WebhooksController < ApplicationController
           remainder -= 1
         end
         EmailManager::PoolDonationReceiptSender.call({
-            payment_intent: payment_intent,
-            amount: amount,
-            email: payment_intent.purchaser.email
-        })
+                                                       payment_intent: payment_intent,
+                                                       amount: amount,
+                                                       email: payment_intent.purchaser.email
+                                                     })
       else
         merchant_name = Seller.find_by(seller_id: seller_id).name
         case item_json['item_type']
@@ -167,11 +165,11 @@ class WebhooksController < ApplicationController
             amount: amount
           )
           EmailManager::DonationReceiptSender.call({
-              payment_intent: payment_intent,
-              amount: amount,
-              merchant: merchant_name,
-              email: payment_intent.purchaser.email
-          })
+                                                     payment_intent: payment_intent,
+                                                     amount: amount,
+                                                     merchant: merchant_name,
+                                                     email: payment_intent.purchaser.email
+                                                   })
         when 'gift_card'
           item = create_item(
             item_type: :gift_card,
@@ -192,19 +190,19 @@ class WebhooksController < ApplicationController
           # Gift a meal purchases are technically donations to the purchaser
           if is_distribution
             EmailManager::DonationReceiptSender.call({
-              payment_intent: payment_intent,
-              amount: amount,
-              merchant: merchant_name,
-              email: payment_intent.purchaser.email
-            })
+                                                       payment_intent: payment_intent,
+                                                       amount: amount,
+                                                       merchant: merchant_name,
+                                                       email: payment_intent.purchaser.email
+                                                     })
           else
             EmailManager::GiftCardReceiptSender.call({
-              payment_intent: payment_intent,
-              amount: amount,
-              merchant: merchant_name,
-              gift_card_detail: gift_card_detail,
-              email: payment_intent.recipient.email
-            })
+                                                       payment_intent: payment_intent,
+                                                       amount: amount,
+                                                       merchant: merchant_name,
+                                                       gift_card_detail: gift_card_detail,
+                                                       email: payment_intent.recipient.email
+                                                     })
           end
         else
           raise(
@@ -252,10 +250,10 @@ class WebhooksController < ApplicationController
 
   def create_item(item_type:, seller_id:, payment_intent:)
     WebhookManager::ItemCreator.call({
-      item_type: item_type,
-      seller_id: seller_id,
-      payment_intent: payment_intent
-    })
+                                       item_type: item_type,
+                                       seller_id: seller_id,
+                                       payment_intent: payment_intent
+                                     })
   end
 
   def generate_gift_card_id

--- a/app/services/email_manager/donation_receipt_sender.rb
+++ b/app/services/email_manager/donation_receipt_sender.rb
@@ -1,11 +1,12 @@
 module EmailManager
   class DonationReceiptSender < BaseService
-    attr_reader :amount, :merchant, :payment_intent
+    attr_reader :amount, :merchant, :payment_intent, :email
 
     def initialize(params)
       @amount = params[:amount]
       @merchant = params[:merchant]
       @payment_intent = params[:payment_intent]
+      @email = params[:email]
     end
 
     # rubocop:disable Layout/LineLength
@@ -21,16 +22,15 @@ module EmailManager
              '<h1>Thank you for your donation to ' + merchant + '!</h1>' \
              '<p> Donation amount: <b>$' + amount_string + '</b></p>' \
              '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
-             "<p> We'll be in touch when " + merchant + ' opens back up. Sending ' \
-             '  thanks from us and from Chinatown for your support! </p>' \
+             '<p> Sending thanks from us and from Chinatown for your support! </p>' \
              '<p> Love,<p>' \
-             '<p> the Send Chinatown Love team</p>' \
+             '<p> Send Chinatown Love</p>' \
              '</body>' \
              '</html>'
-        EmailManager::Sender.send_receipt(to: payment_intent.recipient.email, html: html)
+        EmailManager::Sender.send_receipt(to: email, html: html)
       rescue StandardError
         Rails.logger.error 'Donation email errored out. ' \
-                "email: #{payment_intent.recipient.email}, " \
+                "email: #{email}, " \
                 "receipt: #{payment_intent.receipt_url} " \
                 "amount: #{amount}, merchant: #{merchant}"
       end

--- a/app/services/email_manager/donation_receipt_sender.rb
+++ b/app/services/email_manager/donation_receipt_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EmailManager
   class DonationReceiptSender < BaseService
     attr_reader :amount, :merchant, :payment_intent, :email
@@ -11,29 +13,27 @@ module EmailManager
 
     # rubocop:disable Layout/LineLength
     def call
-      begin
-        amount_string = EmailManager::Sender.format_amount(amount: amount)
-        html = '<!DOCTYPE html>' \
-             '<html>' \
-             '<head>' \
-             "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
-             '</head>' \
-             '<body>' \
-             '<h1>Thank you for your donation to ' + merchant + '!</h1>' \
-             '<p> Donation amount: <b>$' + amount_string + '</b></p>' \
-             '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
-             '<p> Sending thanks from us and from Chinatown for your support! </p>' \
-             '<p> Love,<p>' \
-             '<p> Send Chinatown Love</p>' \
-             '</body>' \
-             '</html>'
-        EmailManager::Sender.send_receipt(to: email, html: html)
-      rescue StandardError
-        Rails.logger.error 'Donation email errored out. ' \
-                "email: #{email}, " \
-                "receipt: #{payment_intent.receipt_url} " \
-                "amount: #{amount}, merchant: #{merchant}"
-      end
+      amount_string = EmailManager::Sender.format_amount(amount: amount)
+      html = '<!DOCTYPE html>' \
+           '<html>' \
+           '<head>' \
+           "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
+           '</head>' \
+           '<body>' \
+           '<h1>Thank you for your donation to ' + merchant + '!</h1>' \
+           '<p> Donation amount: <b>$' + amount_string + '</b></p>' \
+           '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
+           '<p> Sending thanks from us and from Chinatown for your support! </p>' \
+           '<p> Love,<p>' \
+           '<p> Send Chinatown Love</p>' \
+           '</body>' \
+           '</html>'
+      EmailManager::Sender.send_receipt(to: email, html: html)
+    rescue StandardError
+      Rails.logger.error 'Donation email errored out. ' \
+              "email: #{email}, " \
+              "receipt: #{payment_intent.receipt_url} " \
+              "amount: #{amount}, merchant: #{merchant}"
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/email_manager/gift_card_receipt_sender.rb
+++ b/app/services/email_manager/gift_card_receipt_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EmailManager
   class GiftCardReceiptSender < BaseService
     attr_reader :amount, :gift_card_detail, :merchant, :payment_intent
@@ -11,35 +13,33 @@ module EmailManager
 
     # rubocop:disable Layout/LineLength
     def call
-      begin
-        amount_string = EmailManager::Sender.format_amount(amount: amount)
-        html = '<!DOCTYPE html>' \
-             '<html>' \
-             '<head>' \
-             "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
-             '</head>' \
-             '<body>' \
-             '<h1>Thank you for your purchase from ' + merchant + '!</h1>' \
-             '<p> Gift card code: <b>' + gift_card_detail.seller_gift_card_id + '</b></p>' \
-             '<p> Gift card balance: <b>$' + amount_string + '</b></p>' \
-             '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
-             "<p> We'll be in touch when " + merchant + ' opens back up with details' \
-             '  on how to use your gift card. Sending thanks from us and from Chinatown for' \
-             '  your support! </p>' \
-             '<p> Love,<p>' \
-             '<p> the Send Chinatown Love team</p>' \
-             '</body>' \
-             '</html>'
-        EmailManager::Sender.send_receipt(to: payment_intent.recipient.email, html: html)
-      rescue StandardError
-        Rails.logger.error 'Gift card email errored out. ' \
-                "email: #{payment_intent.recipient.email}, " \
-                "receipt: #{payment_intent.receipt_url} " \
-                "amount: #{amount}, " \
-                "merchant: #{merchant}, " \
-                "receipt_id: #{gift_card_detail.seller_gift_card_id}, " \
-                "gift card detail: #{gift_card_detail}"
-      end
+      amount_string = EmailManager::Sender.format_amount(amount: amount)
+      html = '<!DOCTYPE html>' \
+           '<html>' \
+           '<head>' \
+           "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
+           '</head>' \
+           '<body>' \
+           '<h1>Thank you for your purchase from ' + merchant + '!</h1>' \
+           '<p> Gift card code: <b>' + gift_card_detail.seller_gift_card_id + '</b></p>' \
+           '<p> Gift card balance: <b>$' + amount_string + '</b></p>' \
+           '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
+           "<p> We'll be in touch when " + merchant + ' opens back up with details' \
+           '  on how to use your gift card. Sending thanks from us and from Chinatown for' \
+           '  your support! </p>' \
+           '<p> Love,<p>' \
+           '<p> the Send Chinatown Love team</p>' \
+           '</body>' \
+           '</html>'
+      EmailManager::Sender.send_receipt(to: payment_intent.recipient.email, html: html)
+    rescue StandardError
+      Rails.logger.error 'Gift card email errored out. ' \
+              "email: #{payment_intent.recipient.email}, " \
+              "receipt: #{payment_intent.receipt_url} " \
+              "amount: #{amount}, " \
+              "merchant: #{merchant}, " \
+              "receipt_id: #{gift_card_detail.seller_gift_card_id}, " \
+              "gift card detail: #{gift_card_detail}"
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/email_manager/pool_donation_receipt_sender.rb
+++ b/app/services/email_manager/pool_donation_receipt_sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EmailManager
   class PoolDonationReceiptSender < BaseService
     attr_reader :amount, :payment_intent
@@ -9,30 +11,28 @@ module EmailManager
 
     # rubocop:disable Layout/LineLength
     def call
-      begin
-        amount_string = EmailManager::Sender.format_amount(amount: amount)
-        html = '<!DOCTYPE html>' \
-             '<html>' \
-             '<head>' \
-             "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
-             '</head>' \
-             '<body>' \
-             '<h1>Thank you for your donation to Send Chinatown Love!</h1>' \
-             '<p> Donation amount: <b>$' + amount_string + '</b></p>' \
-             '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
-             '<p> You\'re donation will be distributed evenly between our merchants. Sending ' \
-             '  thanks from us and from Chinatown for your support! </p>' \
-             '<p> Love,<p>' \
-             '<p> the Send Chinatown Love team</p>' \
-             '</body>' \
-             '</html>'
-        EmailManager::Sender.send_receipt(to: payment_intent.recipient.email, html: html)
-      rescue StandardError
-        Rails.logger.error 'Pool donation email errored out. ' \
-              "email: #{payment_intent.recipient.email}, " \
-              "receipt: #{payment_intent.receipt_url} " \
-              "amount: #{amount}"
-      end
+      amount_string = EmailManager::Sender.format_amount(amount: amount)
+      html = '<!DOCTYPE html>' \
+           '<html>' \
+           '<head>' \
+           "  <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />" \
+           '</head>' \
+           '<body>' \
+           '<h1>Thank you for your donation to Send Chinatown Love!</h1>' \
+           '<p> Donation amount: <b>$' + amount_string + '</b></p>' \
+           '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
+           '<p> You\'re donation will be distributed evenly between our merchants. Sending ' \
+           '  thanks from us and from Chinatown for your support! </p>' \
+           '<p> Love,<p>' \
+           '<p> the Send Chinatown Love team</p>' \
+           '</body>' \
+           '</html>'
+      EmailManager::Sender.send_receipt(to: payment_intent.recipient.email, html: html)
+    rescue StandardError
+      Rails.logger.error 'Pool donation email errored out. ' \
+            "email: #{payment_intent.recipient.email}, " \
+            "receipt: #{payment_intent.receipt_url} " \
+            "amount: #{amount}"
     end
     # rubocop:enable Layout/LineLength
   end

--- a/app/services/email_manager/sender.rb
+++ b/app/services/email_manager/sender.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EmailManager
   class Sender < BaseService
     def self.format_amount(amount:)

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # Permitted locales available for the application
 I18n.available_locales = [:en, 'zh-CN']

--- a/db/migrate/20200517210843_translate_business_type.rb
+++ b/db/migrate/20200517210843_translate_business_type.rb
@@ -13,4 +13,3 @@ class TranslateBusinessType < ActiveRecord::Migration[6.0]
     end
   end
 end
-

--- a/db/migrate/20200527020111_add_single_use_to_gift_card_detail.rb
+++ b/db/migrate/20200527020111_add_single_use_to_gift_card_detail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSingleUseToGiftCardDetail < ActiveRecord::Migration[6.0]
   def change
     add_column :gift_card_details, :single_use, :boolean, default: false, null: false

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -85,232 +85,232 @@ RSpec.describe 'Webhooks API', type: :request do
       # Give seller2 the most donations
       item = create(:item, seller: seller2)
       create(:donation_detail, item: item, amount: 10_00)
-
-      post(
-        '/webhooks',
-        headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-        params: payload.to_json
-      )
     end
 
-    context 'with pool donation' do
-      let(:seller_id) { seller_pool.seller_id }
-
-      context 'with nice pool donation' do
-        let(:amount) { 5000 }
-        let(:item_type) { 'donation' }
-
-        it 'creates pool donation' do
-          expect(seller1.donation_amount).to eq(25_00)
-          expect(seller2.donation_amount).to eq(35_00)
-        end
-
-        it 'returns status code 200' do
-          expect(response).to have_http_status(200)
-        end
+    describe 'donations' do
+      before do
+        post(
+          '/webhooks',
+          headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+          params: payload.to_json
+        )
       end
 
-      context 'with non-divisible number round' do
-        let(:amount) { 3 }
-        let(:item_type) { 'donation' }
+      context 'with pool donation' do
+        let(:seller_id) { seller_pool.seller_id }
 
-        it 'creates pool donation and distrubutes the cents' do
-          expect(seller1.donation_amount).to eq(2)
-          expect(seller2.donation_amount).to eq(10_01)
-        end
-
-        it 'returns status code 200' do
-          expect(response).to have_http_status(200)
-        end
-      end
-
-      context 'with an extra seller' do
-        let!(:seller3) do
-          create :seller, seller_id: 'great-hall', accept_donations: true
-        end
-
-        context 'with non-divisible number round' do
-          let(:amount) { 335 }
+        context 'with nice pool donation' do
+          let(:amount) { 5000 }
           let(:item_type) { 'donation' }
 
-          it 'creates pool donation and distrubutes the cents' do
-            expect(seller1.donation_amount).to eq(1_12)
-            expect(seller3.donation_amount).to eq(1_12)
-            expect(seller2.donation_amount).to eq(11_11)
+          it 'creates pool donation' do
+            expect(seller1.donation_amount).to eq(25_00)
+            expect(seller2.donation_amount).to eq(35_00)
           end
 
           it 'returns status code 200' do
             expect(response).to have_http_status(200)
           end
         end
-      end
 
-      context 'with erroneous pool gift card' do
-        let(:amount) { 5000 }
-        let(:item_type) { 'gift card' }
+        context 'with non-divisible number round' do
+          let(:amount) { 3 }
+          let(:item_type) { 'donation' }
 
-        it 'returns status code 422' do
-          expect(response.body)
-            .to match(
-              /but found type 'gift card'./
-            )
-
-          expect(response).to have_http_status(422)
-        end
-      end
-    end
-
-    context 'with donation' do
-      let(:amount) { 5000 }
-      let(:item_type) { 'donation' }
-      let(:seller_id) { seller1.seller_id }
-
-      it 'creates a donation' do
-        donation_detail = DonationDetail.last
-        expect(donation_detail).not_to be_nil
-        expect(donation_detail['amount']).to eq(5000)
-
-        item = Item.find(donation_detail['item_id'])
-        expect(item).not_to be_nil
-        expect(item.purchaser).to eq(payment_intent.purchaser)
-        expect(item.donation?).to be true
-        expect(item.seller).to eq(seller1)
-
-        payment_intent = PaymentIntent.find(item['payment_intent_id'])
-        expect(payment_intent.successful).to be true
-      end
-
-      it 'returns status code 200' do
-        expect(response).to have_http_status(200)
-      end
-
-      context 'with refund' do
-        let(:refund_response) do
-          {
-            'refund': {
-              'id': SecureRandom.uuid,
-              'payment_id': payment_intent.square_payment_id,
-              'status': status
-            }
-          }
-        end
-
-        let(:refund_payload) do
-          {
-            'event_id': 'dfgh-4567',
-            'type': payload_type,
-            'data': {
-              'object': refund_response
-            }
-          }
-        end
-
-        before do
-          post(
-            '/webhooks',
-            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-            params: refund_payload.to_json
-          )
-        end
-
-        context 'refund.created' do
-          let(:payload_type) { 'refund.created' }
-          let(:status) { 'PENDING' }
-
-          it 'creates a refund' do
-            refund = Refund.last
-
-            expect(refund).not_to be_nil
-            expect(refund.status).to eq(status)
-            expect(refund.square_refund_id).to eq(
-              refund_response[:refund][:id]
-            )
-            expect(refund.payment_intent_id).to eq(payment_intent.id)
+          it 'creates pool donation and distrubutes the cents' do
+            expect(seller1.donation_amount).to eq(2)
+            expect(seller2.donation_amount).to eq(10_01)
           end
 
-          context 'refund.updated' do
-            before do
-              post(
-                '/webhooks',
-                headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-                params: {
-                  'event_id': 'hjkl-1234',
-                  'type': 'refund.updated',
-                  'data': {
-                    'object': {
-                      'refund': {
-                        'id': SecureRandom.uuid,
-                        'payment_id': payment_intent.square_payment_id,
-                        'status': updated_status
+          it 'returns status code 200' do
+            expect(response).to have_http_status(200)
+          end
+        end
+
+        context 'with an extra seller' do
+          let!(:seller3) do
+            create :seller, seller_id: 'great-hall', accept_donations: true
+          end
+
+          context 'with non-divisible number round' do
+            let(:amount) { 335 }
+            let(:item_type) { 'donation' }
+
+            it 'creates pool donation and distrubutes the cents' do
+              expect(seller1.donation_amount).to eq(1_12)
+              expect(seller3.donation_amount).to eq(1_12)
+              expect(seller2.donation_amount).to eq(11_11)
+            end
+
+            it 'returns status code 200' do
+              expect(response).to have_http_status(200)
+            end
+          end
+        end
+
+        context 'with erroneous pool gift card' do
+          let(:amount) { 5000 }
+          let(:item_type) { 'gift card' }
+
+          it 'returns status code 422' do
+            expect(response.body)
+              .to match(
+                /but found type 'gift card'./
+              )
+
+            expect(response).to have_http_status(422)
+          end
+        end
+      end
+
+      context 'with donation' do
+        let(:amount) { 5000 }
+        let(:item_type) { 'donation' }
+        let(:seller_id) { seller1.seller_id }
+
+        it 'creates a donation' do
+          donation_detail = DonationDetail.last
+          expect(donation_detail).not_to be_nil
+          expect(donation_detail['amount']).to eq(5000)
+
+          item = Item.find(donation_detail['item_id'])
+          expect(item).not_to be_nil
+          expect(item.purchaser).to eq(payment_intent.purchaser)
+          expect(item.donation?).to be true
+          expect(item.seller).to eq(seller1)
+
+          payment_intent = PaymentIntent.find(item['payment_intent_id'])
+          expect(payment_intent.successful).to be true
+        end
+
+        it 'returns status code 200' do
+          expect(response).to have_http_status(200)
+        end
+
+        context 'with refund' do
+          let(:refund_response) do
+            {
+              'refund': {
+                'id': SecureRandom.uuid,
+                'payment_id': payment_intent.square_payment_id,
+                'status': status
+              }
+            }
+          end
+
+          let(:refund_payload) do
+            {
+              'event_id': 'dfgh-4567',
+              'type': payload_type,
+              'data': {
+                'object': refund_response
+              }
+            }
+          end
+
+          before do
+            post(
+              '/webhooks',
+              headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+              params: refund_payload.to_json
+            )
+          end
+
+          context 'refund.created' do
+            let(:payload_type) { 'refund.created' }
+            let(:status) { 'PENDING' }
+
+            it 'creates a refund' do
+              refund = Refund.last
+
+              expect(refund).not_to be_nil
+              expect(refund.status).to eq(status)
+              expect(refund.square_refund_id).to eq(
+                refund_response[:refund][:id]
+              )
+              expect(refund.payment_intent_id).to eq(payment_intent.id)
+            end
+
+            context 'refund.updated' do
+              before do
+                post(
+                  '/webhooks',
+                  headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+                  params: {
+                    'event_id': 'hjkl-1234',
+                    'type': 'refund.updated',
+                    'data': {
+                      'object': {
+                        'refund': {
+                          'id': SecureRandom.uuid,
+                          'payment_id': payment_intent.square_payment_id,
+                          'status': updated_status
+                        }
                       }
                     }
-                  }
-                }.to_json
-              )
-            end
-
-            context 'COMPLETED' do
-              let(:updated_status) { 'COMPLETED' }
-
-              it 'updates the status' do
-                refund = Refund.last
-
-                expect(refund).not_to be_nil
-                expect(refund.status).to eq(updated_status)
+                  }.to_json
+                )
               end
 
-              it 'refunds all of the items' do
-                Refund.last.payment_intent.items.all do |item|
-                  expect(item.refunded).to eq(true)
+              context 'COMPLETED' do
+                let(:updated_status) { 'COMPLETED' }
+
+                it 'updates the status' do
+                  refund = Refund.last
+
+                  expect(refund).not_to be_nil
+                  expect(refund.status).to eq(updated_status)
+                end
+
+                it 'refunds all of the items' do
+                  Refund.last.payment_intent.items.all do |item|
+                    expect(item.refunded).to eq(true)
+                  end
                 end
               end
-            end
 
-            context 'FAILED' do
-              let(:updated_status) { 'FAILED' }
+              context 'FAILED' do
+                let(:updated_status) { 'FAILED' }
 
-              it 'updates the status' do
-                refund = Refund.last
+                it 'updates the status' do
+                  refund = Refund.last
 
-                expect(refund).not_to be_nil
-                expect(refund.status).to eq(updated_status)
-              end
+                  expect(refund).not_to be_nil
+                  expect(refund.status).to eq(updated_status)
+                end
 
-              it "doesn't refund all of the items" do
-                Refund.last.payment_intent.items.all do |item|
-                  expect(item.refunded).to eq(false)
+                it "doesn't refund all of the items" do
+                  Refund.last.payment_intent.items.all do |item|
+                    expect(item.refunded).to eq(false)
+                  end
                 end
               end
             end
           end
         end
-      end
 
-      context 'with duplicate call' do
-        before do
-          post(
-            '/webhooks',
-            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
-            params: payload.to_json
-          )
-        end
-
-        it 'returns status code 400' do
-          expect(response.body)
-            .to match(
-              /Request was already received/
+        context 'with duplicate call' do
+          before do
+            post(
+              '/webhooks',
+              headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+              params: payload.to_json
             )
+          end
 
-          expect(response).to have_http_status(409)
+          it 'returns status code 400' do
+            expect(response.body)
+              .to match(
+                /Request was already received/
+              )
+
+            expect(response).to have_http_status(409)
+          end
         end
       end
     end
 
-    context 'with gift card' do
-      let(:amount) { 5000 }
-      let(:item_type) { 'gift_card' }
-      let(:seller_id) { seller1.seller_id }
-
+    describe 'gift cards' do
       def verify_gift_card(single_use:)
         item = Item.where(
           seller_id: seller1.id,
@@ -335,8 +335,21 @@ RSpec.describe 'Webhooks API', type: :request do
         expect(gift_card_detail.recipient).to eq(payment_intent.recipient)
       end
 
+      let(:amount) { 5000 }
+      let(:item_type) { 'gift_card' }
+      let(:seller_id) { seller1.seller_id }
+
       context 'with is_distribution = true' do
         let(:is_distribution) { true }
+
+        before do
+          expect(EmailManager::DonationReceiptSender).to receive(:call)
+          post(
+            '/webhooks',
+            headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+            params: payload.to_json
+          )
+        end
 
         it 'creates a single use gift card' do
           verify_gift_card(single_use: true)
@@ -347,16 +360,9 @@ RSpec.describe 'Webhooks API', type: :request do
         end
       end
 
-      it 'creates a gift card' do
-        verify_gift_card(single_use: false)
-      end
-
-      it 'returns status code 200' do
-        expect(response).to have_http_status(200)
-      end
-
-      context 'with duplicate call' do
+      context 'with is_distribution = false' do
         before do
+          expect(EmailManager::GiftCardReceiptSender).to receive(:call)
           post(
             '/webhooks',
             headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
@@ -364,13 +370,31 @@ RSpec.describe 'Webhooks API', type: :request do
           )
         end
 
-        it 'returns status code 400' do
-          expect(response.body)
-            .to match(
-              /Request was already received/
-            )
+        it 'creates a gift card' do
+          verify_gift_card(single_use: false)
+        end
 
-          expect(response).to have_http_status(409)
+        it 'returns status code 200' do
+          expect(response).to have_http_status(200)
+        end
+
+        context 'with duplicate call' do
+          before do
+            post(
+              '/webhooks',
+              headers: { 'HTTP_X_SQUARE_SIGNATURE' => 'www.squareup.com' },
+              params: payload.to_json
+            )
+          end
+
+          it 'returns status code 400' do
+            expect(response.body)
+              .to match(
+                /Request was already received/
+              )
+
+            expect(response).to have_http_status(409)
+          end
         end
       end
     end

--- a/spec/services/email_manager/donation_receipt_sender_spec.rb
+++ b/spec/services/email_manager/donation_receipt_sender_spec.rb
@@ -6,6 +6,7 @@ describe EmailManager::DonationReceiptSender, '#call' do
       amount: 5000,
       merchant: "Leaky Cauldron",
       payment_intent: payment_intent,
+      email: 'justin@sendchinatownlove.com'
   }
   end
 

--- a/spec/services/email_manager/donation_receipt_sender_spec.rb
+++ b/spec/services/email_manager/donation_receipt_sender_spec.rb
@@ -2,19 +2,20 @@
 
 describe EmailManager::DonationReceiptSender, '#call' do
   let(:payment_intent) { create :payment_intent }
-  let(:receipt_params) do {
+  let(:receipt_params) do
+    {
       amount: 5000,
-      merchant: "Leaky Cauldron",
+      merchant: 'Leaky Cauldron',
       payment_intent: payment_intent,
       email: 'justin@sendchinatownlove.com'
-  }
+    }
   end
 
   it 'should call donation email sender methods' do
-    sender = class_double("EmailManager::Sender")
-                 .as_stubbed_const(:transfer_nested_constants => true)
+    sender = class_double('EmailManager::Sender')
+             .as_stubbed_const(transfer_nested_constants: true)
     expect(sender).to receive(:format_amount).with(amount: 5000).and_return(
-        "$50.00"
+      '$50.00'
     )
     expect(sender).to receive(:send_receipt)
 

--- a/spec/services/email_manager/gift_card_receipt_sender_spec.rb
+++ b/spec/services/email_manager/gift_card_receipt_sender_spec.rb
@@ -8,6 +8,7 @@ describe EmailManager::GiftCardReceiptSender, '#call' do
       gift_card_detail: gift_card_detail,
       merchant: "Three Broomsticks",
       payment_intent: payment_intent,
+      email: 'justin@sendchinatownlove.com'
   }
   end
 

--- a/spec/services/email_manager/gift_card_receipt_sender_spec.rb
+++ b/spec/services/email_manager/gift_card_receipt_sender_spec.rb
@@ -3,20 +3,21 @@
 describe EmailManager::GiftCardReceiptSender, '#call' do
   let(:payment_intent) { create :payment_intent }
   let(:gift_card_detail) { create :gift_card_detail }
-  let(:receipt_params) do {
+  let(:receipt_params) do
+    {
       amount: 5000,
       gift_card_detail: gift_card_detail,
-      merchant: "Three Broomsticks",
+      merchant: 'Three Broomsticks',
       payment_intent: payment_intent,
       email: 'justin@sendchinatownlove.com'
-  }
+    }
   end
 
   it 'should call gift card donation email sender methods' do
-    sender = class_double("EmailManager::Sender")
-                 .as_stubbed_const(:transfer_nested_constants => true)
+    sender = class_double('EmailManager::Sender')
+             .as_stubbed_const(transfer_nested_constants: true)
     expect(sender).to receive(:format_amount).with(amount: 5000).and_return(
-        "$50.00"
+      '$50.00'
     )
     expect(sender).to receive(:send_receipt)
 

--- a/spec/services/email_manager/pool_donation_receipt_sender_spec.rb
+++ b/spec/services/email_manager/pool_donation_receipt_sender_spec.rb
@@ -5,6 +5,7 @@ describe EmailManager::PoolDonationReceiptSender, '#call' do
   let(:receipt_params) do {
       amount: 5000,
       payment_intent: payment_intent,
+      email: 'justin@sendchinatownlove.com'
   }
   end
 

--- a/spec/services/email_manager/pool_donation_receipt_sender_spec.rb
+++ b/spec/services/email_manager/pool_donation_receipt_sender_spec.rb
@@ -2,18 +2,19 @@
 
 describe EmailManager::PoolDonationReceiptSender, '#call' do
   let(:payment_intent) { create :payment_intent }
-  let(:receipt_params) do {
+  let(:receipt_params) do
+    {
       amount: 5000,
       payment_intent: payment_intent,
       email: 'justin@sendchinatownlove.com'
-  }
+    }
   end
 
   it 'should call pool donation email sender methods' do
-    sender = class_double("EmailManager::Sender")
-                 .as_stubbed_const(:transfer_nested_constants => true)
+    sender = class_double('EmailManager::Sender')
+             .as_stubbed_const(transfer_nested_constants: true)
     expect(sender).to receive(:format_amount).with(amount: 5000).and_return(
-        "$50.00"
+      '$50.00'
     )
     expect(sender).to receive(:send_receipt)
 

--- a/spec/services/webhook_manager/item_creator_spec.rb
+++ b/spec/services/webhook_manager/item_creator_spec.rb
@@ -7,7 +7,7 @@ describe WebhookManager::ItemCreator, '#call' do
   let(:payment_intent) { create :payment_intent }
   let(:payload) do
     {
-      item_type: "donation",
+      item_type: 'donation',
       seller_id: seller.seller_id,
       payment_intent: payment_intent
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = [:should, :expect]
   end
 
   # rspec-mocks config goes here. You can use an alternate test double

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    expectations.syntax = [:should, :expect]
+    expectations.syntax = %i[should expect]
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
We emailing gifted mails to the disitributor, but the
purchaser never got a receipt. We plan to give the distributors
their gift cards manually from pulling from the db, so we
don't need to synchronously send them an email. We'll do
it manually. However, we do need to send an email to the
purchaser.