### PR TITLE
Adding optimistic locking to prevent item creation whenever the lock_version is incorrect

### DIFF
--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -27,6 +27,7 @@ module ExceptionHandler
   # Note that these are evaluated from bottom to top
   included do
     rescue_from ActiveRecord::RecordInvalid,
+                ActiveRecord::StaleObjectError,
                 ActionController::ParameterMissing,
                 InvalidParameterError,
                 InvalidLineItem,

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -151,11 +151,14 @@ class WebhooksController < ApplicationController
                                                      email: payment_intent.purchaser.email
                                                    })
         when 'gift_card'
+
+          is_distribution = item_json['is_distribution']
+
           gift_card_detail = WebhookManager::GiftCardCreator.call({
                                                                     amount: amount,
                                                                     seller_id: seller_id,
                                                                     payment_intent: payment_intent,
-                                                                    single_use: item_json['is_distribution']
+                                                                    single_use: is_distribution
                                                                   })
           # Gift a meal purchases are technically donations to the purchaser
           if is_distribution

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -159,11 +159,11 @@ class WebhooksController < ApplicationController
         merchant_name = Seller.find_by(seller_id: seller_id).name
         case item_json['item_type']
         when 'donation'
-          create_item_and_donation(
+          WebhookManager::DonationCreator.call({
             seller_id: seller_id,
             payment_intent: payment_intent,
             amount: amount
-          )
+          })
           EmailManager::DonationReceiptSender.call({
                                                      payment_intent: payment_intent,
                                                      amount: amount,

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -124,32 +124,12 @@ class WebhooksController < ApplicationController
       if seller_id.eql?(Seller::POOL_DONATION_SELLER_ID)
         PoolDonationValidator.call({ type: item_json['item_type'] })
 
-        # TODO(jtmckibb): This is a very inefficient sort, since each time we
-        #                 call amount_raised, it has to fetch all of the
-        #                 associated Items, DonationDetails, and GiftCardDetails
-        #                 Then for each GiftCardDetail, it has to fetch every
-        #                 amount in an N+1 query, then sum everything. This is
-        #                 all in an N log N sort—which is horrible. Ideally,
-        #                 we would memoize amount_raised, and fix the N+1 query
-        #                 in GiftCardDetail that calculates amount.
-        @donation_sellers = Seller.filter_by_accepts_donations.sort_by(&:amount_raised)
+        WebhookManager::PoolDonationCreator.call({
+          seller_id: seller_id,
+          payment_intent: payment_intent,
+          amount: amount
+        })
 
-        # calculate amount per merchant
-        # This will break if we ever have zero merchants but are still
-        # accepting pool donations.
-        amount_per = (amount.to_f / @donation_sellers.count.to_f).floor
-        remainder = amount % @donation_sellers.count
-
-        @donation_sellers.each do |seller|
-          next if seller.seller_id.eql?(Seller::POOL_DONATION_SELLER_ID)
-
-          create_item_and_donation(
-            seller_id: seller.seller_id,
-            payment_intent: payment_intent,
-            amount: amount_per + (remainder > 0 ? 1 : 0)
-          )
-          remainder -= 1
-        end
         EmailManager::PoolDonationReceiptSender.call({
                                                        payment_intent: payment_intent,
                                                        amount: amount,
@@ -160,10 +140,10 @@ class WebhooksController < ApplicationController
         case item_json['item_type']
         when 'donation'
           WebhookManager::DonationCreator.call({
-            seller_id: seller_id,
-            payment_intent: payment_intent,
-            amount: amount
-          })
+                                                 seller_id: seller_id,
+                                                 payment_intent: payment_intent,
+                                                 amount: amount
+                                               })
           EmailManager::DonationReceiptSender.call({
                                                      payment_intent: payment_intent,
                                                      amount: amount,
@@ -171,22 +151,12 @@ class WebhooksController < ApplicationController
                                                      email: payment_intent.purchaser.email
                                                    })
         when 'gift_card'
-          item = create_item(
-            item_type: :gift_card,
-            seller_id: seller_id,
-            payment_intent: payment_intent
-          )
-
-          is_distribution = item_json['is_distribution']
-
-          gift_card_detail = create_gift_card(
-            item: item,
-            amount: amount,
-            seller_id: seller_id,
-            recipient: recipient,
-            single_use: is_distribution
-          )
-
+          gift_card_detail = WebhookManager::GiftCardCreator.call({
+                                                                    amount: amount,
+                                                                    seller_id: seller_id,
+                                                                    payment_intent: payment_intent,
+                                                                    single_use: item_json['is_distribution']
+                                                                  })
           # Gift a meal purchases are technically donations to the purchaser
           if is_distribution
             EmailManager::DonationReceiptSender.call({
@@ -212,76 +182,5 @@ class WebhooksController < ApplicationController
         end
       end
     end
-
-    # Mark the payment as successful once we've recorded each object purchased
-    # in our DB eg) Donation, Gift Card, etc.
-    payment_intent.successful = true
-    payment_intent.save
-  end
-
-  def create_item_and_donation(seller_id:, payment_intent:, amount:)
-    new_item = create_item(
-      item_type: :donation,
-      seller_id: seller_id,
-      payment_intent: payment_intent
-    )
-    create_donation(item: new_item, amount: amount)
-  end
-
-  def create_donation(item:, amount:)
-    DonationDetail.create!(
-      item: item,
-      amount: amount
-    )
-  end
-
-  def create_gift_card(item:, amount:, seller_id:, recipient:, single_use:)
-    gift_card_detail = GiftCardDetail.create!(
-      expiration: Date.today + 1.year,
-      item: item,
-      gift_card_id: generate_gift_card_id,
-      seller_gift_card_id: generate_seller_gift_card_id(seller_id: seller_id),
-      recipient: recipient,
-      single_use: single_use
-    )
-    GiftCardAmount.create!(value: amount, gift_card_detail: gift_card_detail)
-    gift_card_detail
-  end
-
-  def create_item(item_type:, seller_id:, payment_intent:)
-    WebhookManager::ItemCreator.call({
-                                       item_type: item_type,
-                                       seller_id: seller_id,
-                                       payment_intent: payment_intent
-                                     })
-  end
-
-  def generate_gift_card_id
-    (1..50).each do |_i|
-      potential_id = SecureRandom.uuid
-      # Use this ID if it's not already taken
-      unless GiftCardDetail.where(gift_card_id: potential_id).present?
-        return potential_id
-      end
-    end
-    raise CannotGenerateUniqueHash, 'Error generating unique gift_card_id'
-  end
-
-  def generate_seller_gift_card_id(seller_id:)
-    (1..50).each do |_i|
-      hash = generate_seller_gift_card_id_hash.upcase
-      potential_id_prefix = hash[0...3]
-      potential_id_suffix = hash[3...5]
-      potential_id = "##{potential_id_prefix}-#{potential_id_suffix}"
-      # Use this ID if it's not already taken
-      return potential_id unless GiftCardDetail.where(
-        seller_gift_card_id: potential_id
-      ).joins(:item).where(items: { seller_id: seller_id }).present?
-    end
-    raise CannotGenerateUniqueHash, 'Error generating unique gift_card_id'
-  end
-
-  def generate_seller_gift_card_id_hash
-    ('a'..'z').to_a.sample(5).join
   end
 end

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -6,6 +6,7 @@
 #
 #  id                 :bigint           not null, primary key
 #  line_items         :text
+#  lock_version       :integer
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null

--- a/app/services/webhook_manager/donation_creator.rb
+++ b/app/services/webhook_manager/donation_creator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Validates idempotency using the ExistingEvent Model
+# Creates donation and item with the corresponding payload
 module WebhookManager
   class DonationCreator < BaseService
     attr_reader :seller_id, :payment_intent, :amount

--- a/app/services/webhook_manager/donation_creator.rb
+++ b/app/services/webhook_manager/donation_creator.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Validates idempotency using the ExistingEvent Model
+module WebhookManager
+  class DonationCreator < BaseService
+    attr_reader :seller_id, :payment_intent, :amount
+
+    def initialize(params)
+      @seller_id = params[:seller_id]
+      @payment_intent = params[:payment_intent]
+      @amount = params[:amount]
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        seller = Seller.find_by(seller_id: seller_id)
+        item = WebhookManager::ItemCreator.call({
+          item_type: :donation,
+          seller_id: seller_id,
+          payment_intent: payment_intent
+        })
+        donation = DonationDetail.create!(
+          item: item,
+          amount: amount
+        )
+        payment_intent.successful = true
+        payment_intent.save!
+
+        donation
+      end
+    end
+  end
+end

--- a/app/services/webhook_manager/gift_card_creator.rb
+++ b/app/services/webhook_manager/gift_card_creator.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Creates donation and item with the corresponding payload
+module WebhookManager
+  class GiftCardCreator < BaseService
+    attr_reader :seller_id, :payment_intent, :amount, :single_use
+
+    def initialize(params)
+      @seller_id = params[:seller_id]
+      @payment_intent = params[:payment_intent]
+      @amount = params[:amount]
+      @single_use = params[:single_use]
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        seller = Seller.find_by(seller_id: seller_id)
+        item = WebhookManager::ItemCreator.call({
+          item_type: :gift_card,
+          seller_id: seller_id,
+          payment_intent: payment_intent
+        })
+
+        gift_card_detail = GiftCardDetail.create!(
+          expiration: Date.today + 1.year,
+          item: item,
+          gift_card_id: generate_gift_card_id,
+          seller_gift_card_id: generate_seller_gift_card_id(seller_id: seller_id),
+          recipient: payment_intent.recipient,
+          single_use: single_use
+        )
+        GiftCardAmount.create!(value: amount, gift_card_detail: gift_card_detail)
+        payment_intent.successful = true
+        payment_intent.save!
+
+        gift_card_detail
+      end
+    end
+
+    private
+
+    def generate_gift_card_id
+      (1..50).each do |_i|
+        potential_id = SecureRandom.uuid
+        # Use this ID if it's not already taken
+        unless GiftCardDetail.where(gift_card_id: potential_id).present?
+          return potential_id
+        end
+      end
+      raise CannotGenerateUniqueHash, 'Error generating unique gift_card_id'
+    end
+
+    def generate_seller_gift_card_id(seller_id:)
+      (1..50).each do |_i|
+        hash = generate_seller_gift_card_id_hash.upcase
+        potential_id_prefix = hash[0...3]
+        potential_id_suffix = hash[3...5]
+        potential_id = "##{potential_id_prefix}-#{potential_id_suffix}"
+        # Use this ID if it's not already taken
+        return potential_id unless GiftCardDetail.where(
+          seller_gift_card_id: potential_id
+        ).joins(:item).where(items: { seller_id: seller_id }).present?
+      end
+      raise CannotGenerateUniqueHash, 'Error generating unique gift_card_id'
+    end
+
+    def generate_seller_gift_card_id_hash
+      ('a'..'z').to_a.sample(5).join
+    end
+  end
+end

--- a/app/services/webhook_manager/pool_donation_creator.rb
+++ b/app/services/webhook_manager/pool_donation_creator.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Creates donation and item with the corresponding payload
+module WebhookManager
+  class PoolDonationCreator < BaseService
+    attr_reader :seller_id, :payment_intent, :amount
+
+    def initialize(params)
+      @seller_id = params[:seller_id]
+      @payment_intent = params[:payment_intent]
+      @amount = params[:amount]
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        # TODO(jtmckibb): This is a very inefficient sort, since each time we
+        #                 call amount_raised, it has to fetch all of the
+        #                 associated Items, DonationDetails, and GiftCardDetails
+        #                 Then for each GiftCardDetail, it has to fetch every
+        #                 amount in an N+1 query, then sum everything. This is
+        #                 all in an N log N sort—which is horrible. Ideally,
+        #                 we would memoize amount_raised, and fix the N+1 query
+        #                 in GiftCardDetail that calculates amount.
+        @donation_sellers = Seller.filter_by_accepts_donations.sort_by do |s|
+          s.amount_raised
+        end
+
+        # calculate amount per merchant
+        # This will break if we ever have zero merchants but are still
+        # accepting pool donations.
+        amount_per = (amount.to_f / @donation_sellers.count.to_f).floor
+        remainder = amount % @donation_sellers.count
+
+        donations = @donation_sellers.map do |seller|
+          next if seller.seller_id.eql?(Seller::POOL_DONATION_SELLER_ID)
+
+          item = WebhookManager::ItemCreator.call({
+            item_type: :donation,
+            seller_id: seller.seller_id,
+            payment_intent: payment_intent
+          })
+
+          donation = DonationDetail.create!(
+            item: item,
+            amount: amount_per + (remainder > 0 ? 1 : 0)
+          )
+
+          remainder -= 1
+
+          donation
+        end
+
+        payment_intent.successful = true
+        payment_intent.save!
+
+        donations
+      end
+    end
+  end
+end

--- a/db/migrate/20200530194123_add_lock_version_to_payment_intents.rb
+++ b/db/migrate/20200530194123_add_lock_version_to_payment_intents.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToPaymentIntents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :payment_intents, :lock_version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_30_191835) do
+ActiveRecord::Schema.define(version: 2020_05_30_194123) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 2020_05_30_191835) do
     t.string "receipt_url"
     t.bigint "purchaser_id"
     t.bigint "recipient_id"
+    t.integer "lock_version"
     t.index ["purchaser_id"], name: "index_payment_intents_on_purchaser_id"
     t.index ["recipient_id"], name: "index_payment_intents_on_recipient_id"
   end

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                 :bigint           not null, primary key
 #  line_items         :text
+#  lock_version       :integer
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'Webhooks API', type: :request do
     end
 
     before do
-      allow_any_instance_of(WebhooksController)
+      allow_any_instance_of(WebhookManager::GiftCardCreator)
         .to receive(:generate_seller_gift_card_id_hash)
         .and_return('abcde')
       allow(SecureRandom).to receive(:uuid)

--- a/spec/services/webhook_manager/donation_creator_spec.rb
+++ b/spec/services/webhook_manager/donation_creator_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WebhookManager::DonationCreator, '#call' do
+  let(:seller) { create :seller }
+
+  it 'creates donation' do
+    payment_intent = create :payment_intent
+    payload = new_payload(payment_intent)
+    donation = WebhookManager::DonationCreator.call(payload)
+
+    item = Item.last
+
+    expect(item.seller).to eq(seller)
+    expect(item.purchaser).to eq(payment_intent.purchaser)
+    expect(item.item_type).to eq('donation')
+    expect(donation.item).to eq(item)
+    expect(donation.amount).to eq(payload[:amount])
+    expect(PaymentIntent.last.successful).to be true
+  end
+
+  it 'does not create donation due to stale data' do
+    create :payment_intent
+
+    payment_intent_1 = PaymentIntent.last
+    payment_intent_2 = PaymentIntent.last
+
+    payload = new_payload(payment_intent_1)
+
+    donation = WebhookManager::DonationCreator.call(payload)
+
+    item = Item.last
+    count = Item.count
+
+    expect(item.seller).to eq(seller)
+    expect(item.purchaser).to eq(payment_intent_1.purchaser)
+    expect(item.item_type).to eq('donation')
+    expect(donation.item).to eq(item)
+    expect(donation.amount).to eq(payload[:amount])
+    expect(PaymentIntent.last.successful).to be true
+
+    payload = new_payload(payment_intent_2)
+
+    expect{WebhookManager::DonationCreator.call(payload)}.
+      to raise_error(ActiveRecord::StaleObjectError)
+
+    expect(count).to eq(Item.count)
+  end
+
+  def new_payload(payment_intent)
+    {
+      seller_id: seller.seller_id,
+      payment_intent: payment_intent,
+      amount: 50
+    }
+  end
+end

--- a/spec/services/webhook_manager/gift_card_creator_spec.rb
+++ b/spec/services/webhook_manager/gift_card_creator_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WebhookManager::GiftCardCreator, '#call' do
+  let(:seller) { create :seller }
+
+  it 'creates gift_card_details' do
+    payment_intent = create :payment_intent
+
+    payload = new_payload(payment_intent)
+    gift_card_details = WebhookManager::GiftCardCreator.call(payload)
+
+    item = Item.last
+
+    expect(item.seller).to eq(seller)
+    expect(item.purchaser).to eq(payment_intent.purchaser)
+    expect(item.item_type).to eq('gift_card')
+    expect(gift_card_details.item).to eq(item)
+    expect(gift_card_details.amount).to eq(payload[:amount])
+    expect(gift_card_details.recipient).to eq(payment_intent.recipient)
+    expect(PaymentIntent.last.successful).to be true
+  end
+
+  it 'does not create gift_card_details due to stale data' do
+    create :payment_intent
+
+    payment_intent_1 = PaymentIntent.last
+    payment_intent_2 = PaymentIntent.last
+
+    payload = new_payload(payment_intent_1)
+
+    gift_card_details = WebhookManager::GiftCardCreator.call(payload)
+
+    item = Item.last
+    count = Item.count
+
+    expect(item.seller).to eq(seller)
+    expect(item.purchaser).to eq(payment_intent_1.purchaser)
+    expect(item.item_type).to eq('gift_card')
+    expect(gift_card_details.item).to eq(item)
+    expect(gift_card_details.amount).to eq(payload[:amount])
+    expect(gift_card_details.recipient).to eq(payment_intent_1.recipient)
+    expect(PaymentIntent.last.successful).to be true
+
+    payload = new_payload(payment_intent_2)
+
+    expect{WebhookManager::GiftCardCreator.call(payload)}.
+      to raise_error(ActiveRecord::StaleObjectError)
+
+    expect(count).to eq(Item.count)
+  end
+
+  def new_payload(payment_intent)
+    {
+      seller_id: seller.seller_id,
+      payment_intent: payment_intent,
+      amount: 50,
+      single_use: true
+    }
+  end
+end

--- a/spec/services/webhook_manager/pool_donation_creator_spec.rb
+++ b/spec/services/webhook_manager/pool_donation_creator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe WebhookManager::PoolDonationCreator, '#call' do
+  let(:seller) { create :seller, accept_donations: true }
+
+  it 'creates donation' do
+    # Initialize more than one seller
+    create :seller
+
+    payment_intent = create :payment_intent
+    payload = new_payload(payment_intent)
+    donations = WebhookManager::PoolDonationCreator.call(payload)
+
+    expect(Item.count).to eq(2)
+    expect(DonationDetail.count).to eq(Item.count)
+    donations.each do |donation|
+      expect(donation.amount).to eq(payload[:amount] / 2)
+      item = donation.item
+      expect(item.purchaser).to eq(payment_intent.purchaser)
+      expect(item.item_type).to eq('donation')
+    end
+    expect(PaymentIntent.last.successful).to be true
+  end
+
+  it 'does not create donation due to stale data' do
+    create :payment_intent
+    create :seller
+
+    payment_intent_1 = PaymentIntent.last
+    payment_intent_2 = PaymentIntent.last
+
+    payload = new_payload(payment_intent_1)
+
+    donations = WebhookManager::PoolDonationCreator.call(payload)
+
+    count = Item.count
+
+    expect(Item.count).to eq(2)
+    expect(DonationDetail.count).to eq(Item.count)
+    donations.each do |donation|
+      expect(donation.amount).to eq(payload[:amount] / 2)
+      item = donation.item
+      expect(item.purchaser).to eq(payment_intent_1.purchaser)
+      expect(item.item_type).to eq('donation')
+    end
+    expect(PaymentIntent.last.successful).to be true
+
+    payload = new_payload(payment_intent_2)
+
+    expect{WebhookManager::PoolDonationCreator.call(payload)}.
+      to raise_error(ActiveRecord::StaleObjectError)
+
+    expect(count).to eq(Item.count)
+  end
+
+  def new_payload(payment_intent)
+    {
+      seller_id: seller.seller_id,
+      payment_intent: payment_intent,
+      amount: 50
+    }
+  end
+end

--- a/spec/services/webhook_manager/pool_donation_creator_spec.rb
+++ b/spec/services/webhook_manager/pool_donation_creator_spec.rb
@@ -7,7 +7,7 @@ describe WebhookManager::PoolDonationCreator, '#call' do
 
   it 'creates donation' do
     # Initialize more than one seller
-    create :seller
+    create :seller, accept_donations: true
 
     payment_intent = create :payment_intent
     payload = new_payload(payment_intent)
@@ -26,7 +26,7 @@ describe WebhookManager::PoolDonationCreator, '#call' do
 
   it 'does not create donation due to stale data' do
     create :payment_intent
-    create :seller
+    create :seller, accept_donations: true
 
     payment_intent_1 = PaymentIntent.last
     payment_intent_2 = PaymentIntent.last

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,6 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    expectations.syntax = %i[should expect]
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
This is to prevent duplicate items from being created when our idempotency fails from unexpected events. This is ensure that we don't create items if not needed.

Only did it for basic donations, will be doing the same thing for pool donations and gift_cards 

Have to be careful with the PR so that we don't have to create items manually in case things fail

References:
- Optimistic Locking: https://api.rubyonrails.org/classes/ActiveRecord/Locking/Optimistic.html
- Transaction: https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html