### PR TITLE
Fix bug where DonationReceiptSender.call would fire for each line item

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@
     founded_year: 2013,
     website_url: nil,
     menu_url: nil,
-    square_location_id: 'E4R1NCMHG7B2Y'
+    square_location_id: ENV['SQUARE_LOCATION_ID']
   },
   {
     seller_id: 'send-chinatown-love',

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -3,4 +3,48 @@
 require 'rails_helper'
 
 RSpec.describe WebhooksController, type: :controller do
+  describe "POST create" do
+    let!(:payment_intent) do
+      create :payment_intent, :with_line_items, square_payment_id: 'square-id', square_location_id: "OIJWEOIFJEOIFJ"
+    end
+    let!(:seller_a) do
+      create :seller, seller_id: 42, name: "Toasty Buns"
+    end
+    let!(:seller_b) do
+      create :seller, seller_id: 43, name: "Krusty Krab"
+    end
+
+    before(:each) do
+      allow(EmailManager::DonationReceiptSender).to receive(:call).and_return(nil)
+      allow(SquareManager::WebhookValidator).to receive(:call).and_return(nil)
+      allow(DuplicateRequestValidator).to receive(:call).and_return(nil)
+    end
+
+    context "for 'Gift A Meal' purchases" do
+      it "should send one email per unique seller ID" do
+        line_items_hash = JSON.parse payment_intent.line_items
+        seller_ids = line_items_hash.map{ |li| li["seller_id"] }
+        seller_ids.uniq.length.should == 2
+
+        expect(EmailManager::DonationReceiptSender).to receive(:call).twice
+        post :create, body: request_body
+      end
+    end
+  end
+
+  ### HELPERS ###
+  def request_body
+    { 
+      type: 'payment_updated',
+      data: { 
+        object: { 
+          payment: { 
+            id: payment_intent.square_payment_id,
+            location_id: payment_intent.square_location_id,
+            status: "COMPLETED",
+          },
+        },
+      },                              
+    }.to_json
+  end
 end

--- a/spec/factories/payment_intent.rb
+++ b/spec/factories/payment_intent.rb
@@ -9,4 +9,16 @@ FactoryBot.define do
     association :recipient, factory: :contact
     association :purchaser, factory: :contact
   end
+
+  trait :with_line_items do
+    line_items {
+      %{
+        [
+          {"amount": "100", "seller_id": "42", "item_type": "donation"},
+          {"amount": "200", "seller_id": "42", "item_type": "donation"},
+          {"amount": "300", "seller_id": "43", "item_type": "donation"}
+        ]
+      }
+    }
+  end
 end


### PR DESCRIPTION
Closes issue #149 

Issue: One email would send per line item for donation events.
Solution: Group line items by seller ID, sum the amounts of each group, the send one email per group.

I'm assuming that it's possible for an instance of PaymentIntent to have line items with multiple unique seller IDs.

Additionally, my hunch is that PoolDonationReceiptSender and GiftCardReceiptSender might have the same issue since they're fired within the for-loop; but I don't have as much context on those so I won't touch them.

Let me know if you would like me to refactor anything!