### PR TITLE
Open Hours Backend

### DIFF
--- a/app/controllers/open_hour_controller.rb
+++ b/app/controllers/open_hour_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class OpenHourController < ApplicationController
+  before_action :set_seller
+  before_action :set_seller_open_hour, only: %i[update destroy]
+
+  def index
+    json_response(@seller.open_hour)
+    end
+
+  def create
+    json_response(@seller.open_hour.create!(create_open_hour_params), :created)
+  end
+
+  def update
+    @open_hour.update(update_open_hour_params)
+    @open_hour.save
+    json_response(@open_hour)
+  end
+
+  def destroy
+    @open_hour.destroy
+
+    head :no_content
+  end
+
+  private
+
+  def create_open_hour_params
+    params.require(:seller_id)
+    update_params
+  end
+
+  def update_open_hour_params
+    params.require(:seller_id)
+    params.require(:id)
+    update_params
+  end
+
+  def update_params
+    params.permit(
+      :day,
+      :open,
+      :close
+    )
+  end
+
+  def set_seller
+    @seller = Seller.find_by!(seller_id: params[:seller_id])
+  end
+
+  def set_seller_menu_item
+    @open_hour = @seller.open_hour.find_by!(id: params[:id]) if @seller
+  end
+end

--- a/app/models/open_hour.rb
+++ b/app/models/open_hour.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: open_hours
+#
+#  id         :bigint           not null, primary key
+#  close      :time
+#  day        :integer
+#  open       :time
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  seller_id  :bigint           not null
+#
+# Indexes
+#
+#  index_open_hours_on_seller_id  (seller_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (seller_id => sellers.id)
+#
+class OpenHour < ApplicationRecord
+  belongs_to :seller
+  validates_presence_of :day, :close, :open
+  # 1:Monday - 7:Sunday
+  validates_inclusion_of :day, in: 1..7
+  validate :opens_before_closes
+
+  protected
+
+  def opens_before_closes
+    if open && close && open >= close
+      errors.add(:close, I18n.t('errors.opens_before_closes'))
+    end
+  end
+end

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -54,6 +54,7 @@ class Seller < ApplicationRecord
   has_many :locations, dependent: :destroy
   has_many :menu_items, dependent: :destroy
   has_many :delivery_options, dependent: :destroy
+  has_many :open_hour, dependent: :destroy
   has_many :items, dependent: :destroy
 
   has_one :distributor, class_name: 'Contact'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Rails.application.routes.draw do
   resources :gift_cards do
   end
   resources :sellers do
-    resources :locations, :menu_items, :items
+    resources :locations, :menu_items, :items, :open_hour
   end
   resources :webhooks do
   end

--- a/db/migrate/20200530032154_create_open_hours.rb
+++ b/db/migrate/20200530032154_create_open_hours.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateOpenHours < ActiveRecord::Migration[6.0]
+  def change
+    create_table :open_hours do |t|
+      t.references :seller, null: false, foreign_key: true
+      t.integer :day
+      t.time :open
+      t.time :close
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 2020_06_17_025433) do
+=======
+ActiveRecord::Schema.define(version: 2020_05_30_032154) do
+>>>>>>> 76e518b... open hours backend
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +119,16 @@ ActiveRecord::Schema.define(version: 2020_06_17_025433) do
     t.index ["seller_id"], name: "index_menu_items_on_seller_id"
   end
 
+  create_table "open_hours", force: :cascade do |t|
+    t.bigint "seller_id", null: false
+    t.integer "day"
+    t.time "open"
+    t.time "close"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["seller_id"], name: "index_open_hours_on_seller_id"
+  end
+
   create_table "payment_intents", force: :cascade do |t|
     t.text "line_items"
     t.datetime "created_at", precision: 6, null: false
@@ -187,6 +201,7 @@ ActiveRecord::Schema.define(version: 2020_06_17_025433) do
   add_foreign_key "items", "sellers"
   add_foreign_key "locations", "sellers"
   add_foreign_key "menu_items", "sellers"
+  add_foreign_key "open_hours", "sellers"
   add_foreign_key "payment_intents", "contacts", column: "purchaser_id"
   add_foreign_key "payment_intents", "contacts", column: "recipient_id"
   add_foreign_key "refunds", "payment_intents"

--- a/spec/models/open_hour_spec.rb
+++ b/spec/models/open_hour_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: open_hours
+#
+#  id         :bigint           not null, primary key
+#  close      :time
+#  day        :integer
+#  open       :time
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  seller_id  :bigint           not null
+#
+# Indexes
+#
+#  index_open_hours_on_seller_id  (seller_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (seller_id => sellers.id)
+#
+require 'rails_helper'
+
+RSpec.describe OpenHour, type: :model do
+  it { should belong_to(:seller) }
+end

--- a/spec/requests/open_hour_request_spec.rb
+++ b/spec/requests/open_hour_request_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'OpenHours', type: :request do
+end


### PR DESCRIPTION
Relevant files are open_hour.rb and open_hour_controller.rb

Other files were changes from running rubocop -a. Had some issues rebasing to clean up the commit history but can take another try at it if needed

Heavily based this off of the implementation for menu_items since it seems to be very similar in functionality. 

Open hours are associated with each seller, and contain fields for day of the week (1-7) and open and close times (time datatype).

Does not account for holidays (can add text on frontend).