### PR TITLE
Add giftcard url to gift card receipt email

### DIFF
--- a/app/services/email_manager/gift_card_receipt_sender.rb
+++ b/app/services/email_manager/gift_card_receipt_sender.rb
@@ -14,6 +14,7 @@ module EmailManager
     # rubocop:disable Layout/LineLength
     def call
       amount_string = EmailManager::Sender.format_amount(amount: amount)
+      gift_card_url = 'merchant.sendchinatownlove.com/voucher/' + gift_card_detail.gift_card_id
       html = '<!DOCTYPE html>' \
            '<html>' \
            '<head>' \
@@ -21,7 +22,7 @@ module EmailManager
            '</head>' \
            '<body>' \
            '<h1>Thank you for your purchase from ' + merchant + '!</h1>' \
-           '<p> Gift card code: <b>' + gift_card_detail.seller_gift_card_id + '</b></p>' \
+           '<p> View your gift card <b> <a href="' + gift_card_url + '">Here</a></b></p>' \
            '<p> Gift card balance: <b>$' + amount_string + '</b></p>' \
            '<p> Square receipt: ' + payment_intent.receipt_url + '</p>' \
            "<p> We'll be in touch when " + merchant + ' opens back up with details' \


### PR DESCRIPTION
Link user directly to the gift card they purchased instead of giving them a gift card code.