### PR TITLE
Add divisibility validation for charged amounts and seller cost per meals

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -111,7 +111,8 @@ class ChargesController < ApplicationController
 
       if is_distribution && seller.cost_per_meal.present? && amount % seller.cost_per_meal != 0
         raise InvalidGiftAMealAmountError,
-              "Gift A Meal amount '#{amount}' must be divisible by seller's cost per meal '#{seller.cost_per_meal}'."
+              "Gift A Meal amount '#{amount}' must be divisible by seller's "\
+              "cost per meal '#{seller.cost_per_meal}'."
       end
     end
   end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -15,9 +15,9 @@ class ChargesController < ApplicationController
 
     seller_id = charge_params[:seller_id]
 
-    validate(seller_id: seller_id, line_items: line_items)
-
     is_distribution = charge_params[:is_distribution] || false
+
+    validate(seller_id: seller_id, line_items: line_items, is_distribution: is_distribution)
 
     # Validate each Item and get all ItemTypes
     item_types = Set.new
@@ -77,8 +77,9 @@ class ChargesController < ApplicationController
     )
   end
 
-  def validate(seller_id:, line_items:)
-    unless Seller.find_by(seller_id: seller_id).present?
+  def validate(seller_id:, line_items:, is_distribution:)
+    seller = Seller.find_by(seller_id: seller_id)
+    unless seller.present?
       raise InvalidLineItem, "Seller does not exist: #{seller_id}"
     end
 
@@ -106,6 +107,11 @@ class ChargesController < ApplicationController
       amount = line_item['amount']
       unless amount >= 50
         raise InvalidLineItem, 'Amount must be at least $0.50 usd'
+      end
+
+      if is_distribution && seller.cost_per_meal.present? && amount % seller.cost_per_meal != 0
+        raise InvalidGiftAMealAmountError,
+              "Gift A Meal amount '#{amount}' must be divisible by seller's cost per meal '#{seller.cost_per_meal}'."
       end
     end
   end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -9,6 +9,7 @@ module ExceptionHandler
   class InvalidSquareSignature < StandardError; end
   class DuplicatePaymentCompletedError < StandardError; end
   class InvalidPoolDonationError < StandardError; end
+  class InvalidGiftAMealAmountError < StandardError; end
   class SquarePaymentsError < StandardError
     attr_reader :status_code
     attr_reader :errors
@@ -32,6 +33,7 @@ module ExceptionHandler
                 InvalidParameterError,
                 InvalidLineItem,
                 InvalidGiftCardUpdate,
+                InvalidGiftAMealAmountError,
                 InvalidPoolDonationError do |e|
       json_response({ message: e.message }, :unprocessable_entity)
     end


### PR DESCRIPTION
For the Gift A Meal flow, check that the line item `amount`s are divisible by the seller's `cost_per_meal`.