### PR TITLE
Update Seller Gift Card endpoint to filter out GAM meals

### DIFF
--- a/app/controllers/seller_gift_cards_controller.rb
+++ b/app/controllers/seller_gift_cards_controller.rb
@@ -39,8 +39,8 @@ class SellerGiftCardsController < ApplicationController
   def set_seller
     @seller = Seller.find_by!(seller_id: params[:seller_id])
 
-    #if @seller.gift_cards_access_token != params[:id]
-    #  raise ActiveRecord::RecordNotFound
-    #end
+    if @seller.gift_cards_access_token != params[:id]
+      raise ActiveRecord::RecordNotFound
+    end
   end
 end

--- a/app/controllers/seller_gift_cards_controller.rb
+++ b/app/controllers/seller_gift_cards_controller.rb
@@ -13,8 +13,6 @@ class SellerGiftCardsController < ApplicationController
               :email,
               :created_at,
               :expiration,
-            ).where(
-              single_use: false
             )
             .joins(:item, :recipient)
             .where(
@@ -26,7 +24,10 @@ class SellerGiftCardsController < ApplicationController
             .joins(
               "join (#{GiftCardAmount.latest_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id"
             )
-            .to_sql
+    if params.has_key?('filterGAM')
+      query = query.where(single_use: false)
+    end
+    query = query.to_sql
 
     # processing in one query to get a PG::Result, instead multiple queries when building html
     result = GiftCardDetail.connection.select_all(query)
@@ -38,8 +39,8 @@ class SellerGiftCardsController < ApplicationController
   def set_seller
     @seller = Seller.find_by!(seller_id: params[:seller_id])
 
-    if @seller.gift_cards_access_token != params[:id]
-      raise ActiveRecord::RecordNotFound
-    end
+    #if @seller.gift_cards_access_token != params[:id]
+    #  raise ActiveRecord::RecordNotFound
+    #end
   end
 end

--- a/app/controllers/seller_gift_cards_controller.rb
+++ b/app/controllers/seller_gift_cards_controller.rb
@@ -12,7 +12,7 @@ class SellerGiftCardsController < ApplicationController
               :name,
               :email,
               :created_at,
-              :expiration,
+              :expiration
             )
             .joins(:item, :recipient)
             .where(
@@ -24,9 +24,7 @@ class SellerGiftCardsController < ApplicationController
             .joins(
               "join (#{GiftCardAmount.latest_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id"
             )
-    if params.has_key?('filterGAM')
-      query = query.where(single_use: false)
-    end
+    query = query.where(single_use: false) if params.key?('filterGAM')
     query = query.to_sql
 
     # processing in one query to get a PG::Result, instead multiple queries when building html

--- a/app/controllers/seller_gift_cards_controller.rb
+++ b/app/controllers/seller_gift_cards_controller.rb
@@ -12,7 +12,9 @@ class SellerGiftCardsController < ApplicationController
               :name,
               :email,
               :created_at,
-              :expiration
+              :expiration,
+            ).where(
+              single_use: false
             )
             .joins(:item, :recipient)
             .where(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,26 +94,36 @@ end
     email: 'testytesterson@gmail.com',
     item_type: Item.gift_card,
     refunded: false,
+    single_use: false,
     amounts: [10_000, 8000]
   },
   {
     email: 'testytesterson2@gmail.com',
     item_type: Item.gift_card,
     refunded: true,
+    single_use: false,
     amounts: [7500, 3000]
   },
   {
     email: 'testytesterson3@gmail.com',
     item_type: Item.gift_card,
     refunded: false,
+    single_use: false,
     amounts: [5000]
+  },
+  {
+    email: 'testytesterson4@gmail.com',
+    item_type: Item.gift_card,
+    refunded: false,
+    single_use: true,
+    amounts: [1000]
   }
 ].each do |attributes|
   seller = Seller.find_by(seller_id: 'shunfa-bakery')
   contact = Contact.find_or_create_by!(email: attributes[:email])
   payment_intent = PaymentIntent.create!(recipient: contact, purchaser: contact, square_location_id: seller.square_location_id, square_payment_id: Faker::Alphanumeric.alpha(number: 64))
   item = Item.create!(purchaser: contact, item_type: attributes[:item_type], refunded: attributes[:refunded], seller_id: seller.id, payment_intent_id: payment_intent.id)
-  gift_card_detail = GiftCardDetail.create!(recipient: contact, item_id: item.id, gift_card_id: Faker::Alphanumeric.alpha(number: 64), seller_gift_card_id: Faker::Alphanumeric.alpha(number: 64))
+  gift_card_detail = GiftCardDetail.create!(recipient: contact, item_id: item.id, gift_card_id: Faker::Alphanumeric.alpha(number: 64), seller_gift_card_id: Faker::Alphanumeric.alpha(number: 64), single_use: attributes[:single_use])
   attributes[:amounts].each_with_index do |amount, i|
     GiftCardAmount.create!(gift_card_detail_id: gift_card_detail.id, value: amount, updated_at: Time.now + i.days)
   end

--- a/spec/requests/seller_gift_cards_request_spec.rb
+++ b/spec/requests/seller_gift_cards_request_spec.rb
@@ -15,33 +15,39 @@ RSpec.describe 'SellerGiftCards', type: :request do
       end
 
       let!(:gift_card1) do
-        create_gift_card refunded: false, contact: contact1, seller: seller
+        create_gift_card refunded: false, contact: contact1, seller: seller, single_use: false
       end
 
       let!(:gift_card2) do
-        create_gift_card refunded: false, contact: contact2, seller: seller
+        create_gift_card refunded: false, contact: contact2, seller: seller, single_use: false
       end
 
       let!(:refunded_gift_card) do
-        create_gift_card refunded: true, contact: contact2, seller: seller
+        create_gift_card refunded: true, contact: contact2, seller: seller, single_use: false
+      end
+
+      let!(:GAM_gift_card) do
+        create_gift_card refunded: false, contact: contact2, seller: seller, single_use: true
       end
 
       let!(:gift_card_for_another_seller) do
         create_gift_card(
           refunded: false,
           contact: contact1,
-          seller: create(:seller)
+          seller: create(:seller),
+          single_use: false
         )
       end
 
       let(:expected_gift_card_amount) { 30_00 }
 
-      def create_gift_card(refunded:, contact:, seller:)
+      def create_gift_card(refunded:, contact:, seller:, single_use:)
         item = create(:item, refunded: refunded, seller: seller)
         gift_card_detail = create(
           :gift_card_detail,
           item: item,
-          recipient: contact
+          recipient: contact,
+          single_use: single_use
         )
         create(
           :gift_card_amount,
@@ -62,7 +68,6 @@ RSpec.describe 'SellerGiftCards', type: :request do
           :gift_card_amount,
           gift_card_detail: gift_card_detail
         )
-
         gift_card_detail
       end
 
@@ -85,7 +90,7 @@ RSpec.describe 'SellerGiftCards', type: :request do
         context 'with valid gift_cards_access_token' do
           let(:gift_cards_access_token) { seller.gift_cards_access_token }
 
-          it 'returns all the gift cards except the refunded one' do
+          it 'returns all the gift cards except the refunded and the GAM ones' do
             expect(json).not_to be_empty
             expect(json.size).to eq 2
             expect(json).to eq(

--- a/spec/requests/seller_gift_cards_request_spec.rb
+++ b/spec/requests/seller_gift_cards_request_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'SellerGiftCards', type: :request do
         let(:seller_id) { seller.seller_id }
         let(:gift_cards_access_token) { seller.gift_cards_access_token }
 
-        it 'returns all the gift cards except the refunded one' do
+        it 'returns all the gift cards except the refunded and the GAM one' do
           expect(json).not_to be_empty
           expect(json.size).to eq 2
           expect(json).to eq(


### PR DESCRIPTION
Works on the assumption that all GAM gift cards will have single_use: true, and that no non-GAM gift cards will have single_use: true

Updated spec tests to include a single_use giftcard, and seedfile to include a single_use giftcards
