### PR TITLE
Fix broken migration

### DIFF
--- a/db/migrate/20200726220247_migrate_distributor_to_new_distributor.rb
+++ b/db/migrate/20200726220247_migrate_distributor_to_new_distributor.rb
@@ -7,7 +7,7 @@ class MigrateDistributorToNewDistributor < ActiveRecord::Migration[6.0]
 
     sellers = Seller.all
     sellers.each do |seller|
-      contact = seller.distributor
+      contact = Contact.find_by(seller_id: seller.id)
 
       # If there is a distributor for the Seller, then there was a previous
       # campaign. So far, only 46 Mott and Melonpanna should have had previous
@@ -16,9 +16,12 @@ class MigrateDistributorToNewDistributor < ActiveRecord::Migration[6.0]
 
       # NB(justintmckibben): Remember to update the end_date of past campaigns
       # to the real end_date
-      campaign = Campaign.create valid: true, end_date: Time.now
-      campaign.seller = seller
-      campaign.distributor = Distributor.create contact: contact
+      distributor = Distributor.create contact: contact
+      Campaign.create(
+        valid: true,
+        end_date: Time.now,
+        distributor: distributor,
+        seller: seller)
     end
 
     remove_column :contacts, :seller_id


### PR DESCRIPTION
We removed the relationship to Contact from the Seller model so
when we ran the migration, Seller.distributor indeed does not
exist. We have to get the Contact the old fasioned way without
the model relationship.

Also, Campaign has required fields:
 - seller

So we have to be sure it's there when we created it