### PR TITLE
Adding a new "original amounts" query and using it for the seller progress bar

### DIFF
--- a/app/models/gift_card_amount.rb
+++ b/app/models/gift_card_amount.rb
@@ -27,4 +27,11 @@ class GiftCardAmount < ApplicationRecord
       .order(:gift_card_detail_id, created_at: :desc)
       .to_sql
   end
+
+  def self.original_amounts_sql
+    GiftCardAmount
+      .select('distinct on (gift_card_detail_id) *')
+      .order(:gift_card_detail_id, created_at: :asc)
+      .to_sql
+  end
 end

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -86,7 +86,7 @@ class Seller < ApplicationRecord
                seller_id: id,
                refunded: false
              })
-      .joins("join (#{GiftCardAmount.latest_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id")
+      .joins("join (#{GiftCardAmount.original_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id")
       .sum(:value)
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,9 +43,9 @@ ActiveRecord::Schema.define(version: 2020_08_06_053537) do
   create_table "delivery_options", force: :cascade do |t|
     t.string "url"
     t.string "phone_number"
-    t.bigint "seller_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "seller_id", null: false
     t.index ["seller_id"], name: "index_delivery_options_on_seller_id"
   end
 

--- a/spec/helpers/sellers_helper_spec.rb
+++ b/spec/helpers/sellers_helper_spec.rb
@@ -111,8 +111,8 @@ RSpec.describe SellersHelper, type: :helper do
         create(:donation_detail, item: item_donation2, amount: 10_00)
 
         expected_seller['donation_amount'] = 210_00
-        expected_seller['amount_raised'] = 290_00
-        expected_seller['gift_card_amount'] = 80_00
+        expected_seller['amount_raised'] = 310_00
+        expected_seller['gift_card_amount'] = 100_00
         expected_seller['num_contributions'] = 4
         expected_seller['num_gift_cards'] = 2
         expected_seller['num_donations'] = 2

--- a/spec/models/seller_spec.rb
+++ b/spec/models/seller_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Seller, type: :model do
       end
 
       it 'returns total amount' do
-        expect(seller.amount_raised).to eq(290_00)
+        expect(seller.amount_raised).to eq(310_00)
         expect(seller.num_contributions).to eq(4)
       end
     end

--- a/spec/models/seller_spec.rb
+++ b/spec/models/seller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Seller, type: :model do
       end
 
       it 'returns gift card amounts' do
-        expect(seller.gift_card_amount).to eq(80_00)
+        expect(seller.gift_card_amount).to eq(100_00)
         expect(seller.num_gift_cards).to eq(2)
       end
 


### PR DESCRIPTION
- When doing the `distinct on` query, order by ascending (oldest) amounts instead of descending (newest).
- Keeping both queries as we still use the `latest` for the merchant dashboard and both are useful
- Switching seller endpoint to calculate based on original, not latest amounts
- Updated unit tests with the new expected amounts
- running `rails db:migrate` wanted to move a schema row, so I let it