### PR TITLE
Add name field to distributor

### DIFF
--- a/app/controllers/distributors_controller.rb
+++ b/app/controllers/distributors_controller.rb
@@ -18,7 +18,8 @@ class DistributorsController < ApplicationController
     params.permit(
       :website_url,
       :image_url,
-      :contact_id
+      :contact_id,
+      :name
     )
   end
 

--- a/app/models/distributor.rb
+++ b/app/models/distributor.rb
@@ -6,6 +6,7 @@
 #
 #  id          :bigint           not null, primary key
 #  image_url   :string
+#  name        :string
 #  website_url :string
 #  contact_id  :bigint
 #

--- a/db/migrate/20200807031712_add_name_to_distributors.rb
+++ b/db/migrate/20200807031712_add_name_to_distributors.rb
@@ -1,0 +1,5 @@
+class AddNameToDistributors < ActiveRecord::Migration[6.0]
+  def change
+    add_column :distributors, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_053537) do
+ActiveRecord::Schema.define(version: 2020_08_07_031712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2020_08_06_053537) do
     t.string "website_url"
     t.string "image_url"
     t.bigint "contact_id"
+    t.string "name"
     t.index ["contact_id"], name: "index_distributors_on_contact_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -144,7 +144,7 @@ end
 
 seller = Seller.find_by(seller_id: 'shunfa-bakery')
 contact = Contact.find_or_create_by!(name: 'Apex for Youth', email: 'distributor@apexforyouth.com')
-distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com', website_url: 'apexforyouth.com'
+distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com', website_url: 'apexforyouth.com', name: 'Apex for Youth'
 Campaign.create(
   seller_id: seller.id,
   distributor: distributor,

--- a/spec/factories/distributor.rb
+++ b/spec/factories/distributor.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     association :contact
     image_url { Faker::Alphanumeric.alphanumeric(number: 64) }
     website_url { Faker::Alphanumeric.alphanumeric(number: 64) }
+    name { Faker::name }
   end
 end

--- a/spec/requests/distributors_request_spec.rb
+++ b/spec/requests/distributors_request_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Distributors", type: :request do
         expect(json['image_url']).to eq distributor.image_url
         expect(json['website_url']).to eq distributor.website_url
         expect(json['contact_id']).to eq distributor.contact_id
+        expect(json['name']).to eq distributor.name
       end
 
       it 'returns status code 200' do
@@ -48,7 +49,8 @@ RSpec.describe "Distributors", type: :request do
         {
           contact_id: contact.id,
           website_url: 'sendchinatownlove.com',
-          image_url: 'sendchinatownlove.com/lalalllala'
+          image_url: 'sendchinatownlove.com/lalalllala',
+          name: 'Send Chinatown Love'
         }
       end
 
@@ -56,6 +58,7 @@ RSpec.describe "Distributors", type: :request do
         expect(json['image_url']).to eq attrs[:image_url]
         expect(json['website_url']).to eq attrs[:website_url]
         expect(json['contact_id']).to eq attrs[:contact_id]
+        expect(json['name']).to eq attrs[:name]
         expect(json['id']).not_to be_nil
 
         distributor = Distributor.find_by(contact_id: attrs[:contact_id])
@@ -63,6 +66,7 @@ RSpec.describe "Distributors", type: :request do
         expect(distributor.image_url).to eq attrs[:image_url]
         expect(distributor.website_url).to eq attrs[:website_url]
         expect(distributor.contact_id).to eq attrs[:contact_id]
+        expect(distributor.name).to eq attrs[:name]
       end
 
       it 'returns status code 201' do


### PR DESCRIPTION
Add the organization name to the distributor model. This field is required to render the GAM campaign title of the format "Merchant name x Distributor name"
1. The distributor contact name is not reliable since it's often the name of a person and not the org.
2. Reduces the # of server calls required from the front-end. Only one call to the server to fetch the distributor is needed, as opposed to two calls to fetch the distributor and the contact.

Test plan
```
danthaman-mac:ruby danthaman$ heroku local:run bundle exec rspec spec/requests/distributors_request_spec.rb
[OKAY] Loaded ENV .env File as KEY=VALUE Format
........

Finished in 0.40248 seconds (files took 2.05 seconds to load)
8 examples, 0 failures
```

<img width="1717" alt="Screen Shot 2020-08-06 at 11 29 44 PM" src="https://user-images.githubusercontent.com/2313868/89606057-1713ce00-d83d-11ea-8679-6088ffd83b77.png">
