### PR TITLE
Add neighborhood field to location model

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -37,7 +37,7 @@ class LocationsController < ApplicationController
   end
 
   def update_location_params
-    params.permit(:city, :state, :address1, :address2, :zip_code, :phone_number)
+    params.permit(:city, :state, :address1, :address2, :zip_code, :phone_number, :neighborhood)
   end
 
   def set_seller

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -8,6 +8,7 @@
 #  address1     :string           not null
 #  address2     :string
 #  city         :string           not null
+#  neighborhood :string
 #  phone_number :string
 #  state        :string           not null
 #  zip_code     :string           not null

--- a/db/migrate/20200814034110_add_neighborhood_to_locations.rb
+++ b/db/migrate/20200814034110_add_neighborhood_to_locations.rb
@@ -1,0 +1,5 @@
+class AddNeighborhoodToLocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locations, :neighborhood, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_13_020145) do
+ActiveRecord::Schema.define(version: 2020_08_14_034110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2020_08_13_020145) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "phone_number"
+    t.string "neighborhood"
     t.index ["seller_id"], name: "index_locations_on_seller_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -155,7 +155,7 @@ end
 seller = Seller.find_by(seller_id: 'shunfa-bakery')
 contact = Contact.find_or_create_by!(name: 'Apex for Youth', email: 'distributor@apexforyouth.com')
 distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com', website_url: 'apexforyouth.com', name: 'Apex for Youth'
-location = Location.create(address1: '123 Mott St.', city: 'Zoo York', state: 'NY', zip_code: '12345')
+location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborhood: 'Chinatown', state: 'NY', zip_code: '12345')
 Campaign.create(
   seller_id: seller.id,
   distributor: distributor,

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :location do
     address1 { Faker::Address.street_address }
     address2 { Faker::Address.secondary_address }
+    neighborhood { Faker::Address.community }
     city { Faker::Address.city }
     state { Faker::Address.state_abbr }
     phone_number { Faker::PhoneNumber.cell_phone }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -8,6 +8,7 @@
 #  address1     :string           not null
 #  address2     :string
 #  city         :string           not null
+#  neighborhood :string
 #  phone_number :string
 #  state        :string           not null
 #  zip_code     :string           not null


### PR DESCRIPTION
The new GAM page shows the merchant's neighborhood ("Chinatown", "Sunset Park") in addition to their city/borough. Adding this field
<img width="735" alt="Screen Shot 2020-08-14 at 12 00 16 AM" src="https://user-images.githubusercontent.com/2313868/90212554-9cf5c300-ddc1-11ea-94c9-a6fb4331d3a7.png">

Test plan:
<img width="390" alt="Screen Shot 2020-08-13 at 11 56 15 PM" src="https://user-images.githubusercontent.com/2313868/90212547-99623c00-ddc1-11ea-8e9f-e7daa4c94425.png">

ruby/spec/requests/locations_spec.rb passes
