### PR TITLE
Add borough field to Location model

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -37,7 +37,7 @@ class LocationsController < ApplicationController
   end
 
   def update_location_params
-    params.permit(:city, :state, :address1, :address2, :zip_code, :phone_number, :neighborhood)
+    params.permit(:city, :state, :address1, :address2, :zip_code, :phone_number, :neighborhood, :borough)
   end
 
   def set_seller

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,6 +7,7 @@
 #  id           :bigint           not null, primary key
 #  address1     :string           not null
 #  address2     :string
+#  borough      :string
 #  city         :string           not null
 #  neighborhood :string
 #  phone_number :string

--- a/db/migrate/20200815013131_add_borough_to_locations.rb
+++ b/db/migrate/20200815013131_add_borough_to_locations.rb
@@ -1,0 +1,5 @@
+class AddBoroughToLocations < ActiveRecord::Migration[6.0]
+  def change
+    add_column :locations, :borough, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_172026) do
+ActiveRecord::Schema.define(version: 2020_08_15_013131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,6 +137,7 @@ ActiveRecord::Schema.define(version: 2020_08_14_172026) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "phone_number"
     t.string "neighborhood"
+    t.string "borough"
     t.index ["seller_id"], name: "index_locations_on_seller_id"
   end
 

--- a/spec/factories/location.rb
+++ b/spec/factories/location.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :location do
     address1 { Faker::Address.street_address }
     address2 { Faker::Address.secondary_address }
+    borough { Faker::Address.community }
     neighborhood { Faker::Address.community }
     city { Faker::Address.city }
     state { Faker::Address.state_abbr }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -7,6 +7,7 @@
 #  id           :bigint           not null, primary key
 #  address1     :string           not null
 #  address2     :string
+#  borough      :string
 #  city         :string           not null
 #  neighborhood :string
 #  phone_number :string


### PR DESCRIPTION
The new GAM page requires showing the merchants borough. Right now we're using the City field for that, but thats technically not correct. Add a "borough" field so we can sanitize our data.

Test plan:
```
danthaman-mac:ruby danthaman$ heroku local:run bundle exec rspec spec/requests/locations_spec.rb
[OKAY] Loaded ENV .env File as KEY=VALUE Format
...............

Finished in 1.12 seconds (files took 1.55 seconds to load)
15 examples, 0 failures
```

<img width="389" alt="Screen Shot 2020-08-14 at 9 37 34 PM" src="https://user-images.githubusercontent.com/2313868/90302765-aa20b980-de76-11ea-9c6b-bbc5394626e3.png">
