### PR TITLE
Added PUT endpoint to distributor controller

### DIFF
--- a/app/controllers/distributors_controller.rb
+++ b/app/controllers/distributors_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DistributorsController < ApplicationController
-  before_action :set_distributor, only: %i[show]
+  before_action :set_distributor, only: %i[show update]
 
   # POST /distributors
   def create
@@ -13,10 +13,25 @@ class DistributorsController < ApplicationController
     json_response(@distributor)
   end
 
+  # PUT /distributors/:id
+  def update
+    @distributor.update(update_params)
+    json_response(@distributor)
+  end
+
   private
 
   def create_params
     params.require(:contact_id)
+    params.permit(
+      :website_url,
+      :image_url,
+      :contact_id,
+      :name
+    )
+  end
+
+  def update_params
     params.permit(
       :website_url,
       :image_url,

--- a/spec/requests/distributors_request_spec.rb
+++ b/spec/requests/distributors_request_spec.rb
@@ -90,4 +90,50 @@ RSpec.describe 'Distributors', type: :request do
       end
     end
   end
+
+  describe 'PUT /distributors/:id' do
+    let!(:distributor) { create :distributor }
+    let!(:contact) { create :contact }
+    before do
+      put(
+        "/distributors/#{distributor_id}",
+        params: attrs,
+        as: :json
+      )
+    end
+
+    context 'with valid attrs' do
+      let(:distributor_id) { distributor.id }
+      let(:attrs) do
+        {
+          website_url: 'sendchinatownlove.com',
+          image_url: 'sendchinatownlove.com/lalalllala',
+          name: 'Send Chinatown Love',
+          contact_id: contact.id,
+        }
+      end
+
+      it 'updates the distributor' do
+        distributor = Distributor.find_by(contact_id: attrs[:contact_id])
+        expect(distributor).not_to be_nil
+        expect(distributor.image_url).to eq attrs[:image_url]
+        expect(distributor.website_url).to eq attrs[:website_url]
+        expect(distributor.contact_id).to eq attrs[:contact_id]
+        expect(distributor.name).to eq attrs[:name]
+      end
+
+      it 'returns the updated distributor' do
+        distributor = Distributor.find_by(contact_id: attrs[:contact_id])
+        expect(json['image_url']).to eq attrs[:image_url]
+        expect(json['website_url']).to eq attrs[:website_url]
+        expect(json['name']).to eq attrs[:name]
+        expect(json['contact_id']).to eq attrs[:contact_id]
+        expect(json['id']).to eq distributor.id
+      end
+
+      it 'returns status code 200' do
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adding a PUT endpoint to enable updating of the production Distributor data from Postman

Test plan:
```
danthaman-mac:ruby danthaman$ heroku local:run bundle exec rspec spec/requests/distributors_request_spec.rb
[OKAY] Loaded ENV .env File as KEY=VALUE Format
...........

Finished in 0.42943 seconds (files took 1.57 seconds to load)
11 examples, 0 failures
```

Verified Distributors can be updated via postman
<img width="928" alt="Screen Shot 2020-08-14 at 11 26 13 PM" src="https://user-images.githubusercontent.com/2313868/90304423-9466c080-de85-11ea-9cb2-7201099c5781.png">
