### PR TITLE
Returning more info for seller gift card query

### DIFF
--- a/app/controllers/seller_gift_cards_controller.rb
+++ b/app/controllers/seller_gift_cards_controller.rb
@@ -8,11 +8,14 @@ class SellerGiftCardsController < ApplicationController
     query = GiftCardDetail
             .select(
               :seller_gift_card_id,
-              :value,
+              'la.value as latest_value',
+              'og.value as original_value',
               :name,
               :email,
               :created_at,
-              :expiration
+              :updated_at,
+              :expiration,
+              :single_use
             )
             .joins(:item, :recipient)
             .where(
@@ -23,6 +26,9 @@ class SellerGiftCardsController < ApplicationController
             )
             .joins(
               "join (#{GiftCardAmount.latest_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id"
+            )
+            .joins(
+              "join (#{GiftCardAmount.original_amounts_sql}) as og on og.gift_card_detail_id = gift_card_details.id"
             )
     query = query.where(single_use: false) if params.key?('filterGAM')
     query = query.to_sql

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -123,7 +123,7 @@ end
   contact = Contact.find_or_create_by!(email: attributes[:email])
   payment_intent = PaymentIntent.create!(recipient: contact, purchaser: contact, square_location_id: seller.square_location_id, square_payment_id: Faker::Alphanumeric.alpha(number: 64))
   item = Item.create!(purchaser: contact, item_type: attributes[:item_type], refunded: attributes[:refunded], seller_id: seller.id, payment_intent_id: payment_intent.id)
-  gift_card_detail = GiftCardDetail.create!(recipient: contact, item_id: item.id, gift_card_id: Faker::Alphanumeric.alpha(number: 64), seller_gift_card_id: Faker::Alphanumeric.alpha(number: 64), single_use: attributes[:single_use])
+  gift_card_detail = GiftCardDetail.create!(recipient: contact, item_id: item.id, gift_card_id: Faker::Alphanumeric.alpha(number: 64), seller_gift_card_id: '#' + Faker::Alphanumeric.alpha(number: 5).upcase.insert(3, '-'), single_use: attributes[:single_use])
   attributes[:amounts].each_with_index do |amount, i|
     GiftCardAmount.create!(gift_card_detail_id: gift_card_detail.id, value: amount, updated_at: Time.now + i.days)
   end

--- a/spec/factories/gift_card_detail.rb
+++ b/spec/factories/gift_card_detail.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :gift_card_detail do
     gift_card_id { Faker::Alphanumeric.alphanumeric(number: 64) }
-    seller_gift_card_id { '#' + Faker::Alphanumeric.alphanumeric(number: 5) }
+    seller_gift_card_id { '#' + Faker::Alphanumeric.alphanumeric(number: 5).upcase.insert(3, '-') }
     receipt_id { Faker::Alphanumeric.alphanumeric(number: 64) }
     expiration do
       Faker::Date.between(

--- a/spec/requests/seller_gift_cards_request_spec.rb
+++ b/spec/requests/seller_gift_cards_request_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe 'SellerGiftCards', type: :request do
         )
       end
 
-      let(:expected_gift_card_amount) { 30_00 }
+      let(:expected_gift_card_latest_amount) { 30_00 }
+      let(:expected_gift_card_original_amount) { 10_00 }
 
       def create_gift_card(refunded:, contact:, seller:, single_use:)
         item = create(:item, refunded: refunded, seller: seller)
@@ -52,18 +53,20 @@ RSpec.describe 'SellerGiftCards', type: :request do
           recipient: contact,
           single_use: single_use
         )
+        # the original amount, which matters
         create(
           :gift_card_amount,
+          value: expected_gift_card_original_amount, 
           gift_card_detail: gift_card_detail
         )
         create(
           :gift_card_amount,
           gift_card_detail: gift_card_detail
         )
-        # The amount that matters
+        # The latest amount, which matters
         create(
           :gift_card_amount,
-          value: expected_gift_card_amount,
+          value: expected_gift_card_latest_amount,
           gift_card_detail: gift_card_detail,
           created_at: Time.current + 1.day
         )
@@ -77,11 +80,14 @@ RSpec.describe 'SellerGiftCards', type: :request do
       def expected_gift_card_json(gift_card_detail:, contact:)
         {
           seller_gift_card_id: gift_card_detail.seller_gift_card_id,
-          value: expected_gift_card_amount,
+          latest_value: expected_gift_card_latest_amount,
+          original_value: expected_gift_card_original_amount,
           name: contact.name,
           email: contact.email,
           created_at: gift_card_detail.created_at.utc,
-          expiration: gift_card_detail.expiration
+          expiration: gift_card_detail.expiration,
+          single_use: gift_card_detail.single_use,
+          updated_at: gift_card_detail.updated_at.utc,
         }.as_json
       end
 


### PR DESCRIPTION
- Now returning latest and original amounts
- Returning updated time and single use
- Updating seeds and factory to our actual gift card format of #AAA-AA
- Updated unit tests to new expected values

**Note:** this is a breaking change for the front-end as I'm no longer sending `value` but instead, `original_value` and `latest_value`. The corresponding front-end change is https://github.com/sendchinatownlove/sendchinatownlove.github.io/pull/319. When both are approved I'll merge them together. As not many people (nobody?) is checking this page right now I think that should be sufficient.