### PR TITLE
Fix tickets to use ticket_id instead of id

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -5,14 +5,7 @@ class TicketsController < ApplicationController
   before_action :set_contact, only: %i[update]
   before_action :set_participating_seller, only: %i[create]
 
-  # GET /tickets
-  def index
-    @tickets = Ticket.all
-
-    json_response(@tickets)
-  end
-
-  # GET /tickets/1
+  # GET /tickets/:ticket_id
   def show
     json_response(@ticket)
   end
@@ -36,7 +29,7 @@ class TicketsController < ApplicationController
     json_response(created_tickets, :created)
   end
 
-  # PATCH/PUT /tickets/1
+  # PATCH/PUT /tickets/:ticket_id
   def update
     @ticket.update!(ticket_params)
 
@@ -46,7 +39,7 @@ class TicketsController < ApplicationController
   private
 
   def set_ticket
-    @ticket = Ticket.find(params[:id])
+    @ticket = Ticket.find_by(ticket_id: params[:id])
   end
 
   def set_participating_seller

--- a/spec/requests/tickets_spec.rb
+++ b/spec/requests/tickets_spec.rb
@@ -73,18 +73,10 @@ RSpec.describe '/tickets', type: :request do
   end
 
   # Tests
-  describe 'GET /index' do
-    it 'renders a successful response' do
-      Ticket.create! base_attributes
-      get tickets_url, as: :json
-      expect(response).to be_successful
-    end
-  end
-
   describe 'GET /show' do
     it 'renders a successful response' do
       ticket = Ticket.create! base_attributes
-      get ticket_url(ticket), as: :json
+      get ticket_url(ticket.ticket_id), as: :json
       expect(response).to be_successful
     end
   end
@@ -148,7 +140,7 @@ RSpec.describe '/tickets', type: :request do
     context 'with valid parameters' do
       it 'updates the requested ticket with a valid contact' do
         ticket = Ticket.create! base_attributes
-        put ticket_url(ticket),
+        put ticket_url(ticket.ticket_id),
             params: update_attributes, as: :json
         ticket.reload
         expect(ticket[:contact_id]).not_to be_nil
@@ -157,7 +149,7 @@ RSpec.describe '/tickets', type: :request do
 
       it 'renders a JSON response with the ticket with a valid contact' do
         ticket = Ticket.create! base_attributes
-        put ticket_url(ticket),
+        put ticket_url(ticket.ticket_id),
             params: update_attributes, as: :json
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to match(a_string_including('application/json'))
@@ -167,7 +159,7 @@ RSpec.describe '/tickets', type: :request do
         ticket = Ticket.create! base_attributes_with_contact
         expect(ticket.contact_id).to eq(contact1.id)
 
-        put ticket_url(ticket),
+        put ticket_url(ticket.ticket_id),
             params: update_attributes, as: :json
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to match(a_string_including('application/json'))
@@ -178,7 +170,7 @@ RSpec.describe '/tickets', type: :request do
 
       it 'does not change any attribute other than contact_id' do
         ticket = Ticket.create! base_attributes
-        put ticket_url(ticket),
+        put ticket_url(ticket.ticket_id),
             params: update_attributes, as: :json
         expect(response).to have_http_status(:ok)
         expect(response.content_type).to match(a_string_including('application/json'))
@@ -191,7 +183,7 @@ RSpec.describe '/tickets', type: :request do
     context 'with invalid parameters' do
       it 'renders a JSON response with errors for the ticket without a valid contact' do
         ticket = Ticket.create! base_attributes
-        put ticket_url(ticket),
+        put ticket_url(ticket.ticket_id),
             params: invalid_update_attributes, as: :json
         expect(response).to have_http_status(:not_found)
         expect(response.content_type).to match(a_string_including('application/json'))


### PR DESCRIPTION
This way people can't redeem a ticket by guessing
a number. I also deleted the GET all tickets endpoint
because we don't want people getting all of the ticket
ids of a merchant