### PR TITLE
Allow updates of Campaign's price_per_meal

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -43,7 +43,7 @@ class CampaignsController < ApplicationController
       :active,
       :description,
       :end_date,
-      :cost_per_meal,
+      :price_per_meal,
       :target_amount,
       gallery_image_urls: []
     )
@@ -63,6 +63,7 @@ class CampaignsController < ApplicationController
       :active,
       :description,
       :valid,
+      :price_per_meal,
       gallery_image_urls: []
     )
   end


### PR DESCRIPTION
-Allow the PUT/update method to update a campaign's `price_per_meal`. 
-Renames the `cost_per_meal` param in the POST/create method to `price_per_meal` for consistency. 

Test plan:
POST and PUT both work using POSTMAN