### PR TITLE
use sponsor_seller_id instead of redeemed_at in contact_ticket controller

### DIFF
--- a/app/controllers/contact_tickets_controller.rb
+++ b/app/controllers/contact_tickets_controller.rb
@@ -28,7 +28,7 @@ class ContactTicketsController < ApplicationController
       )
       raise ActiveRecord::RecordNotFound unless ticket.present?
 
-      sponsor_seller_id = t[:redeemed_at]
+      sponsor_seller_id = t[:sponsor_seller_id]
       if sponsor_seller_id_to_tickets[sponsor_seller_id].nil?
         sponsor_seller_id_to_tickets[sponsor_seller_id] = []
       end
@@ -54,7 +54,7 @@ class ContactTicketsController < ApplicationController
 
   def update_params
     params.require(:tickets)
-    params.permit(tickets: %i[id redeemed_at])
+    params.permit(tickets: %i[id sponsor_seller_id])
   end
 
   def set_contact

--- a/spec/requests/contact_tickets_request_spec.rb
+++ b/spec/requests/contact_tickets_request_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe 'ContactTickets', type: :request do
       let(:attrs) do
         {
           tickets: [
-            { id: redeemed_ticket.id, redeemed_at: sponsor_seller2.id },
-            { id: ticket3.id, redeemed_at: sponsor_seller2.id }
+            { id: redeemed_ticket.id, sponsor_seller_id: sponsor_seller2.id },
+            { id: ticket3.id, sponsor_seller_id: sponsor_seller2.id }
           ]
         }
       end
@@ -106,8 +106,8 @@ RSpec.describe 'ContactTickets', type: :request do
       let(:attrs) do
         {
           tickets: [
-            { id: ticket1.id, redeemed_at: sponsor_seller2.id },
-            { id: ticket2.id, redeemed_at: sponsor_seller2.id }
+            { id: ticket1.id, sponsor_seller_id: sponsor_seller2.id },
+            { id: ticket2.id, sponsor_seller_id: sponsor_seller2.id }
           ]
         }
       end
@@ -137,10 +137,10 @@ RSpec.describe 'ContactTickets', type: :request do
             ]
           )
           expect(updated_ticket1.sponsor_seller.id).to eq(
-            attrs[:tickets][0][:redeemed_at]
+            attrs[:tickets][0][:sponsor_seller_id]
           )
           expect(updated_ticket2.sponsor_seller.id).to eq(
-            attrs[:tickets][1][:redeemed_at]
+            attrs[:tickets][1][:sponsor_seller_id]
           )
         end
 
@@ -152,8 +152,8 @@ RSpec.describe 'ContactTickets', type: :request do
           let(:attrs) do
             {
               tickets: [
-                { id: ticket1.id, redeemed_at: sponsor_seller1.id },
-                { id: ticket3.id, redeemed_at: sponsor_seller2.id } # does not own
+                { id: ticket1.id, sponsor_seller_id: sponsor_seller1.id },
+                { id: ticket3.id, sponsor_seller_id: sponsor_seller2.id } # does not own
               ]
             }
           end
@@ -177,7 +177,7 @@ RSpec.describe 'ContactTickets', type: :request do
         {
           tickets: [
             # sponsor_seller2 has a reward_cost of 2
-            { id: ticket1.id, redeemed_at: sponsor_seller2.id }
+            { id: ticket1.id, sponsor_seller_id: sponsor_seller2.id }
           ]
         }
       end
@@ -199,8 +199,8 @@ RSpec.describe 'ContactTickets', type: :request do
         {
           tickets: [
             # sponsor_seller1 has a reward_cost of 1
-            { id: ticket1.id, redeemed_at: sponsor_seller1.id },
-            { id: ticket2.id, redeemed_at: sponsor_seller1.id }
+            { id: ticket1.id, sponsor_seller_id: sponsor_seller1.id },
+            { id: ticket2.id, sponsor_seller_id: sponsor_seller1.id }
           ]
         }
       end


### PR DESCRIPTION
we want it to be clear in our API what redeemed_at means (the location a ticket was redeemed at vs the time it was redeemed at)