### PR TITLE
Add a printed boolean to tickets

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  expiration              :date
+#  printed                 :boolean          default(FALSE), not null
 #  redeemed_at             :date
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null

--- a/db/migrate/20200827044947_add_printed_to_tickets.rb
+++ b/db/migrate/20200827044947_add_printed_to_tickets.rb
@@ -1,0 +1,12 @@
+class AddPrintedToTickets < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tickets, :printed, :boolean, null: false, default: false
+
+    # NB(justintmckibben): At the time of running this migration, all of the
+    #                      existing tickets that were created were already
+    #                      printed
+    Ticket.all.each do |ticket|
+      ticket.update(printed: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_27_050811) do
+ActiveRecord::Schema.define(version: 2020_08_27_044947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,9 +45,9 @@ ActiveRecord::Schema.define(version: 2020_08_27_050811) do
   create_table "delivery_options", force: :cascade do |t|
     t.string "url"
     t.string "phone_number"
+    t.bigint "seller_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "seller_id", null: false
     t.index ["seller_id"], name: "index_delivery_options_on_seller_id"
   end
 
@@ -260,6 +260,7 @@ ActiveRecord::Schema.define(version: 2020_08_27_050811) do
     t.date "expiration"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "printed", default: false, null: false
     t.index ["contact_id"], name: "index_tickets_on_contact_id"
     t.index ["participating_seller_id"], name: "index_tickets_on_participating_seller_id"
     t.index ["sponsor_seller_id"], name: "index_tickets_on_sponsor_seller_id"

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  expiration              :date
+#  printed                 :boolean          default(FALSE), not null
 #  redeemed_at             :date
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null


### PR DESCRIPTION
This way we can differentiate new tickets that
we've created that still need to be printed. This
is also useful for when we create "test" tickets
in the prod DB so that we know that we can safely
delete these tickets.