### PR TITLE
Add support for subheader in rewards page

### DIFF
--- a/app/controllers/sponsor_sellers_controller.rb
+++ b/app/controllers/sponsor_sellers_controller.rb
@@ -31,7 +31,8 @@ class SponsorSellersController < ApplicationController
       :location_id,
       :logo_url,
       :reward,
-      :reward_cost
+      :reward_cost,
+      :reward_detail
     )
   end
 

--- a/app/models/sponsor_seller.rb
+++ b/app/models/sponsor_seller.rb
@@ -4,14 +4,15 @@
 #
 # Table name: sponsor_sellers
 #
-#  id          :bigint           not null, primary key
-#  logo_url    :string
-#  name        :string
-#  reward      :string
-#  reward_cost :integer          default(3), not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  location_id :bigint
+#  id            :bigint           not null, primary key
+#  logo_url      :string
+#  name          :string
+#  reward        :string
+#  reward_cost   :integer          default(3), not null
+#  reward_detail :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  location_id   :bigint
 #
 class SponsorSeller < ApplicationRecord
   validates_presence_of :reward_cost

--- a/db/migrate/20200827050811_add_reward_detail_to_sponsor_seller.rb
+++ b/db/migrate/20200827050811_add_reward_detail_to_sponsor_seller.rb
@@ -1,0 +1,5 @@
+class AddRewardDetailToSponsorSeller < ActiveRecord::Migration[6.0]
+  def change
+    add_column :sponsor_sellers, :reward_detail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_17_030307) do
+ActiveRecord::Schema.define(version: 2020_08_27_050811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,6 +248,7 @@ ActiveRecord::Schema.define(version: 2020_08_17_030307) do
     t.integer "reward_cost", default: 3, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "reward_detail"
   end
 
   create_table "tickets", force: :cascade do |t|

--- a/spec/requests/sponsor_sellers_request_spec.rb
+++ b/spec/requests/sponsor_sellers_request_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(json['id']).to eq sponsor_seller.id
         expect(json['reward_cost']).to eq sponsor_seller.reward_cost
         expect(json['reward']).to eq sponsor_seller.reward
+        expect(json['reward_detail']).to eq sponsor_seller.reward_detail
         expect(json['logo_url']).to eq sponsor_seller.logo_url
         expect(json['location_id']).to eq sponsor_seller.location_id
         expect(json['name']).to eq sponsor_seller.name
@@ -70,7 +71,8 @@ RSpec.describe 'SponsorSellers', type: :request do
           name: 'Boys Sometimes Cry',
           logo_url: 'sendchinatownlove.com/lalalllala',
           reward: 'Free Shot in the Dark',
-          reward_cost: 3
+          reward_cost: 3,
+          reward_detail: 'only valid after sunset'
         }
       end
 
@@ -80,6 +82,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(json['id']).to eq sponsor_seller.id
         expect(json['reward_cost']).to eq sponsor_seller.reward_cost
         expect(json['reward']).to eq sponsor_seller.reward
+        expect(json['reward_detail']).to eq sponsor_seller.reward_detail
         expect(json['logo_url']).to eq sponsor_seller.logo_url
         expect(json['location_id']).to eq sponsor_seller.location_id
         expect(json['name']).to eq sponsor_seller.name
@@ -87,6 +90,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(sponsor_seller).not_to be_nil
         expect(sponsor_seller.reward_cost).to eq attrs[:reward_cost]
         expect(sponsor_seller.reward).to eq attrs[:reward]
+        expect(sponsor_seller.reward_detail).to eq attrs[:reward_detail]
         expect(sponsor_seller.logo_url).to eq attrs[:logo_url]
         expect(sponsor_seller.location_id).to eq attrs[:location_id]
         expect(sponsor_seller.name).to eq attrs[:name]
@@ -115,6 +119,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(json['id']).to eq sponsor_seller.id
         expect(json['reward_cost']).to eq sponsor_seller.reward_cost
         expect(json['reward']).to eq sponsor_seller.reward
+        expect(json['reward_detail']).to eq sponsor_seller.reward_detail
         expect(json['logo_url']).to eq sponsor_seller.logo_url
         expect(json['location_id']).to eq sponsor_seller.location_id
         expect(json['name']).to eq sponsor_seller.name
@@ -122,6 +127,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(sponsor_seller).not_to be_nil
         expect(sponsor_seller.reward_cost).to eq attrs[:reward_cost]
         expect(sponsor_seller.reward).to eq attrs[:reward]
+        expect(sponsor_seller.reward_detail).to eq attrs[:reward_detail]
         expect(sponsor_seller.logo_url).to eq attrs[:logo_url]
         expect(sponsor_seller.location_id).to eq attrs[:location_id]
         expect(sponsor_seller.name).to eq attrs[:name]
@@ -152,7 +158,8 @@ RSpec.describe 'SponsorSellers', type: :request do
           name: 'Boys Sometimes Cry',
           logo_url: 'sendchinatownlove.com/lalalllala',
           reward: 'Free Shot in the Dark',
-          reward_cost: 3
+          reward_cost: 3,
+          reward_detail: 'only valid after sunset'
         }
       end
 
@@ -161,6 +168,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         expect(sponsor_seller).not_to be_nil
         expect(sponsor_seller.reward_cost).to eq attrs[:reward_cost]
         expect(sponsor_seller.reward).to eq attrs[:reward]
+        expect(sponsor_seller.reward_detail).to eq attrs[:reward_detail]
         expect(sponsor_seller.logo_url).to eq attrs[:logo_url]
         expect(sponsor_seller.location_id).to eq attrs[:location_id]
         expect(sponsor_seller.name).to eq attrs[:name]
@@ -171,6 +179,7 @@ RSpec.describe 'SponsorSellers', type: :request do
         sponsor_seller = SponsorSeller.find(json['id'])
         expect(json['reward_cost']).to eq sponsor_seller.reward_cost
         expect(json['reward']).to eq sponsor_seller.reward
+        expect(json['reward_detail']).to eq sponsor_seller.reward_detail
         expect(json['logo_url']).to eq sponsor_seller.logo_url
         expect(json['location_id']).to eq sponsor_seller.location_id
         expect(json['name']).to eq sponsor_seller.name


### PR DESCRIPTION
https://docs.google.com/document/d/1Cy9qmh-PwKc3P6Q9KPhmsLQ7j5VBzDSDmKixu1HcJi4/edit?disco=AAAAKKBa6to
We didn't notice during the RFC that we could have
two sizes of text inside of the cards for sponor
sellers.