### PR TITLE
Don't update token when requesting rewards token twice in a row

### DIFF
--- a/app/controllers/contact_rewards_controller.rb
+++ b/app/controllers/contact_rewards_controller.rb
@@ -5,7 +5,15 @@ class ContactRewardsController < ApplicationController
   def create
     ActiveRecord::Base.transaction do
       contact = Contact.find(params[:contact_id])
-      token = 'token_' + ULID.generate
+
+      # If they've already requested an email within the last 30 minutes, use
+      # the same token
+      token = if Time.now < contact.expires_at
+        contact.rewards_redemption_access_token
+      else
+        # Otherwise generate a new one
+        'token_' + ULID.generate
+      end
 
       contact.update(
         expires_at: Time.now + 30.minutes,


### PR DESCRIPTION
Sometimes when you double submit to get an email sent,
the endpoint will send multiple emails. This can get
confusing for a user since they won't know which email
has the active token. Therefore we updated it so that
it doesn't create a new token unless the last one is
expired.

Note that each time you hit the endpoint though it will
update the expiration time to give an additional 30 mins
for that token.