### PR TITLE
Always lowercase emails

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -58,6 +58,8 @@ class ContactsController < ApplicationController
                            params[:instagram].tr('@', '')
     end
 
+    params[:email] = params[:email].downcase
+
     params.permit(
       :email,
       :instagram,


### PR DESCRIPTION
Validated locally that this works, in the screenshot below I created "testerdude@gmail.com", then tried "TESTERDUDE@gmail.com" and it failed. This same action before this line would succeed and create a new contact. (note: print statements added for console clarity before and after operation)

![image](https://user-images.githubusercontent.com/2818246/91788523-6d74f200-ebda-11ea-9b02-7077b69d25c0.png)
