### PR TITLE
Fix undefined exception if email is not provided in param

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -58,7 +58,7 @@ class ContactsController < ApplicationController
                            params[:instagram].tr('@', '')
     end
 
-    params[:email] = params[:email].downcase
+    params[:email] = params[:email].downcase if params[:email].present?
 
     params.permit(
       :email,


### PR DESCRIPTION
Was receiving a bunch of email notification that we couldn't update the contact.