### PR TITLE
Pagination and Query Params for Participating Sellers Tickets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,6 @@ gem "annotate", "~> 3.1"
 gem 'safe_attributes'
 
 gem 'ulid'
+
+# pagination gem
+gem 'pagy', '~> 3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    pagy (3.8.3)
     parallel (1.19.1)
     parser (2.7.1.1)
       ast (~> 2.4.0)
@@ -287,6 +288,7 @@ DEPENDENCIES
   globalize (~> 5.3.0)
   globalize-accessors
   listen (>= 3.0.5, < 3.2)
+  pagy (~> 3.8)
   pg
   pry-byebug
   puma (~> 4.3)

--- a/app/controllers/participating_seller_tickets_controller.rb
+++ b/app/controllers/participating_seller_tickets_controller.rb
@@ -7,9 +7,6 @@ class ParticipatingSellerTicketsController < ApplicationController
 
   # GET /participating_sellers/:participating_seller_id/tickets/:tickets_secret
   def show
-    # NB(justintmckibben): Do we want to hide the tickets that have already
-    #                      been redeemed aka the ones with associated contacts?
-
     query = Ticket.where(participating_seller: @participating_seller)
     query = query.where(printed: params[:printed]) if params.key?('printed')
 

--- a/app/controllers/participating_seller_tickets_controller.rb
+++ b/app/controllers/participating_seller_tickets_controller.rb
@@ -4,10 +4,11 @@ include Pagy::Backend
 
 class ParticipatingSellerTicketsController < ApplicationController
   before_action :set_participating_seller
+  after_action { pagy_headers_merge(@pagy) if @pagy }
 
   # GET /participating_sellers/:participating_seller_id/tickets/:tickets_secret
   def show
-    query = Ticket.where(participating_seller: @participating_seller)
+    query = Ticket.where(participating_seller: @participating_seller).order(id: :asc)
     query = query.where(printed: params[:printed]) if params.key?('printed')
 
     if params.key?('associated')
@@ -19,7 +20,7 @@ class ParticipatingSellerTicketsController < ApplicationController
     end
 
     @pagy, @records = pagy(query)
-    json_response({ data: @records, pagy: pagy_metadata(@pagy) })
+    json_response(@records)
   end
 
   private

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -75,9 +75,9 @@
 
 # Items extra: Allow the client to request a custom number of items per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/extras/items
-# require 'pagy/extras/items'
-# Pagy::VARS[:items_param] = :items    # default
-# Pagy::VARS[:max_items]   = 100       # default
+require 'pagy/extras/items'
+Pagy::VARS[:items_param] = :items    # default
+Pagy::VARS[:max_items]   = 1000
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -66,7 +66,7 @@
 
 # Headers extra: http response headers (and other helpers) useful for API pagination
 # See http://ddnexus.github.io/pagy/extras/headers
-# require 'pagy/extras/headers'
+require 'pagy/extras/headers'
 # Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
 
 # Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
@@ -88,7 +88,7 @@ Pagy::VARS[:max_items]   = 1000 # standard set of ticket printing, also a reason
 # See https://ddnexus.github.io/pagy/extras/metadata
 # you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
 # require 'pagy/extras/shared'
-require 'pagy/extras/metadata'
+# require 'pagy/extras/metadata'
 # For performance reason, you should explicitly set ONLY the metadata you use in the frontend
 # Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+# Pagy initializer file (3.8.3)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+# require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+# Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -76,7 +76,7 @@
 # Items extra: Allow the client to request a custom number of items per page with an optional selector UI
 # See https://ddnexus.github.io/pagy/extras/items
 require 'pagy/extras/items'
-Pagy::VARS[:items_param] = :items    # default
+Pagy::VARS[:items_param] = :items # default
 Pagy::VARS[:max_items]   = 1000 # standard set of ticket printing, also a reasonable cap for perfomance reasons
 
 # Overflow extra: Allow for easy handling of overflowing pages

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -77,7 +77,7 @@
 # See https://ddnexus.github.io/pagy/extras/items
 require 'pagy/extras/items'
 Pagy::VARS[:items_param] = :items    # default
-Pagy::VARS[:max_items]   = 1000
+Pagy::VARS[:max_items]   = 1000 # standard set of ticket printing, also a reasonable cap for perfomance reasons
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow
@@ -103,7 +103,7 @@ require 'pagy/extras/metadata'
 
 # Instance variables
 # See https://ddnexus.github.io/pagy/api/pagy#instance-variables
-# Pagy::VARS[:items] = 20                                   # default
+Pagy::VARS[:items] = 50 # nice round number to default to
 
 # Other Variables
 # See https://ddnexus.github.io/pagy/api/pagy#other-variables

--- a/spec/requests/participating_seller_tickets_request_spec.rb
+++ b/spec/requests/participating_seller_tickets_request_spec.rb
@@ -79,4 +79,107 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
       expect(response).to have_http_status(200)
     end
   end
+
+  context 'with query params' do
+    # setup different query param variations
+    let!(:participating_sellerA) do
+      create :participating_seller
+    end
+
+    let!(:ticket00) do
+      create :ticket, participating_seller: participating_sellerA, printed: false, associated_with_contact_at: nil
+    end
+    let!(:ticket01) do
+      create :ticket, participating_seller: participating_sellerA, printed: false, associated_with_contact_at: Date.current
+    end
+    let!(:ticket10) do
+      create :ticket, participating_seller: participating_sellerA, printed: true, associated_with_contact_at: nil
+    end
+    let!(:ticket11) do
+      create :ticket, participating_seller: participating_sellerA, printed: true, associated_with_contact_at: Date.current
+    end
+
+    let(:tickets_secret) { participating_sellerA.tickets_secret }
+    let(:participating_seller_id) { participating_sellerA.id }
+
+    it 'returns all four tickets with no query params' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 4
+      expect(json['data']).to eq(
+        [
+          ticket00.as_json,
+          ticket01.as_json,
+          ticket10.as_json,
+          ticket11.as_json
+        ]
+      )
+    end
+
+    it 'returns correct two tickets for printed: false' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=false"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 2
+      expect(json['data']).to eq(
+        [
+          ticket00.as_json,
+          ticket01.as_json
+        ]
+      )
+    end
+
+    it 'returns correct two tickets for printed: true' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=true"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 2
+      expect(json['data']).to eq(
+        [
+          ticket10.as_json,
+          ticket11.as_json
+        ]
+      )
+    end
+
+    it 'returns correct two tickets for associated: false' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?associated=false"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 2
+      expect(json['data']).to eq(
+        [
+          ticket00.as_json,
+          ticket10.as_json
+        ]
+      )
+    end
+
+    it 'returns correct two tickets for associated: true' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?associated=true"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 2
+      expect(json['data']).to eq(
+        [
+          ticket01.as_json,
+          ticket11.as_json
+        ]
+      )
+    end
+
+    # spot check one double query case
+    it 'returns correct two tickets for printed: false, associated: false' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=false&associated=false"
+
+      expect(json['data']).not_to be_empty
+      expect(json['data'].size).to eq 1
+      expect(json['data']).to eq(
+        [
+          ticket00.as_json
+        ]
+      )
+    end
+  end
 end

--- a/spec/requests/participating_seller_tickets_request_spec.rb
+++ b/spec/requests/participating_seller_tickets_request_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
       let(:tickets_secret) { participating_seller1.tickets_secret }
 
       it 'returns all the tickets for seller' do
-        expect(json).not_to be_empty
-        expect(json.size).to eq 2
-        expect(json).to eq(
+        expect(json['data']).not_to be_empty
+        expect(json['data'].size).to eq 2
+        expect(json['data']).to eq(
           [
             ticket1.as_json,
             ticket2.as_json
@@ -72,7 +72,7 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     before { get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}" }
 
     it 'returns empty array' do
-      expect(json).to be_empty
+      expect(json['data']).to be_empty
     end
 
     it 'returns 200' do

--- a/spec/requests/participating_seller_tickets_request_spec.rb
+++ b/spec/requests/participating_seller_tickets_request_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
       let(:tickets_secret) { participating_seller1.tickets_secret }
 
       it 'returns all the tickets for seller' do
-        expect(json['data']).not_to be_empty
-        expect(json['data'].size).to eq 2
-        expect(json['data']).to eq(
+        expect(json).not_to be_empty
+        expect(json.size).to eq 2
+        expect(json).to eq(
           [
             ticket1.as_json,
             ticket2.as_json
@@ -72,7 +72,7 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     before { get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}" }
 
     it 'returns empty array' do
-      expect(json['data']).to be_empty
+      expect(json).to be_empty
     end
 
     it 'returns 200' do
@@ -105,9 +105,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns all four tickets with no query params' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 4
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 4
+      expect(json).to eq(
         [
           ticket00.as_json,
           ticket01.as_json,
@@ -120,9 +120,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns correct two tickets for printed: false' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=false"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 2
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 2
+      expect(json).to eq(
         [
           ticket00.as_json,
           ticket01.as_json
@@ -133,9 +133,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns correct two tickets for printed: true' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=true"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 2
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 2
+      expect(json).to eq(
         [
           ticket10.as_json,
           ticket11.as_json
@@ -146,9 +146,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns correct two tickets for associated: false' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?associated=false"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 2
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 2
+      expect(json).to eq(
         [
           ticket00.as_json,
           ticket10.as_json
@@ -159,9 +159,9 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns correct two tickets for associated: true' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?associated=true"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 2
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 2
+      expect(json).to eq(
         [
           ticket01.as_json,
           ticket11.as_json
@@ -173,13 +173,39 @@ RSpec.describe 'ParticipatingSellerTickets', type: :request do
     it 'returns correct two tickets for printed: false, associated: false' do
       get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?printed=false&associated=false"
 
-      expect(json['data']).not_to be_empty
-      expect(json['data'].size).to eq 1
-      expect(json['data']).to eq(
+      expect(json).not_to be_empty
+      expect(json.size).to eq 1
+      expect(json).to eq(
         [
           ticket00.as_json
         ]
       )
     end
+  end
+
+  context 'with some basic pagination' do
+    let(:tickets_secret) { participating_seller1.tickets_secret }
+    let(:participating_seller_id) { participating_seller1.id }
+
+    it 'returns both records for default pagination' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}"
+      expect(json).not_to be_empty
+      expect(json.size).to eq 2
+
+      expect(response.headers['Current-Page'].to_i).to eq 1
+      expect(response.headers['Total-Pages'].to_i).to eq 1
+      expect(response.headers['Total-Count'].to_i).to eq 2
+    end
+
+    it 'returns one record and two total pages when specifying one per page' do
+      get "/participating_sellers/#{participating_seller_id}/tickets/#{tickets_secret}?items=1"
+      expect(json).not_to be_empty
+      expect(json.size).to eq 1
+
+      expect(response.headers['Current-Page'].to_i).to eq 1
+      expect(response.headers['Total-Pages'].to_i).to eq 2
+      expect(response.headers['Total-Count'].to_i).to eq 2
+    end
+
   end
 end


### PR DESCRIPTION
- Add Pagy for controlling pagination
- Number of items controlled in request (default 50, max 1000)
- Query on either `printed` or `associated_with_contact_at`, to filter items as desired
- Unit tests for the query params, and some basic pagination tests
- Adding pagy metadata to the headers

Followup:
- Once the front-end implements the change (either passthrough of url params or a UI), we can reduce the pagy metadata to what's actually needed