### PR TITLE
Return 200 success if lyft reward is successfully claimed

### DIFF
--- a/app/controllers/contact_lyft_rewards_controller.rb
+++ b/app/controllers/contact_lyft_rewards_controller.rb
@@ -41,6 +41,7 @@ class ContactLyftRewardsController < ApplicationController
         state: 'delivered',
         token: token
       )
+      json_response({})
     end
   end
 


### PR DESCRIPTION
The server needs to return a Success code to the front-end, or the front-end will get an error and show the wrong modal