### PR TITLE
Return GAM in seller model (Chris' change)

### DIFF
--- a/app/helpers/sellers_helper.rb
+++ b/app/helpers/sellers_helper.rb
@@ -25,6 +25,7 @@ module SellersHelper
     end
 
     json['donation_amount'] = seller.donation_amount
+    json['gift_a_meal_amount'] = seller.gift_a_meal_amount
     json['gift_card_amount'] = seller.gift_card_amount
     json['amount_raised'] = json['donation_amount'] + json['gift_card_amount']
 

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -101,6 +101,21 @@ class Seller < ApplicationRecord
       .sum(:amount)
   end
 
+  # Calculates the amount raised from gift a meal. Gift a meal donations come in as single-use gift cards.
+  def gift_a_meal_amount
+    GiftCardDetail
+      .where(
+        single_use: true,
+      )
+      .joins(:item)
+      .where(items: {
+              refunded: false,
+              seller_id: id,
+            })
+      .joins("join (#{GiftCardAmount.original_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id")
+      .sum(:value)
+  end
+
   def num_contributions
     num_gift_cards + num_donations
   end

--- a/spec/helpers/sellers_helper_spec.rb
+++ b/spec/helpers/sellers_helper_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe SellersHelper, type: :helper do
         'amount_raised': 0,
         'donation_amount': 0,
         'gift_card_amount': 0,
+        'gift_a_meal_amount': 0,
         'num_contributions': 0,
         'num_gift_cards': 0,
         'num_donations': 0
@@ -102,6 +103,15 @@ RSpec.describe SellersHelper, type: :helper do
           created_at: Time.current + 1.day
         )
 
+        # Create gift-a-meal gift card of $10.
+        gift_a_meal1 = create(:item, seller: seller)
+        gift_card_detail3 = create(:gift_card_detail, item: item_gift_card1, single_use: true)
+        create(
+          :gift_card_amount,
+          value: 10_00,
+          gift_card_detail: gift_card_detail3,
+        )
+        
         # Create a donation of $200
         item_donation1 = create(:item, seller: seller)
         create(:donation_detail, item: item_donation1, amount: 200_00)
@@ -111,10 +121,11 @@ RSpec.describe SellersHelper, type: :helper do
         create(:donation_detail, item: item_donation2, amount: 10_00)
 
         expected_seller['donation_amount'] = 210_00
-        expected_seller['amount_raised'] = 310_00
-        expected_seller['gift_card_amount'] = 100_00
-        expected_seller['num_contributions'] = 4
-        expected_seller['num_gift_cards'] = 2
+        expected_seller['amount_raised'] = 320_00
+        expected_seller['gift_card_amount'] = 110_00
+        expected_seller['gift_a_meal_amount'] = 10_00
+        expected_seller['num_contributions'] = 5
+        expected_seller['num_gift_cards'] = 3
         expected_seller['num_donations'] = 2
       end
 


### PR DESCRIPTION
Return GAM in seller model. Right now, we return the gift card amount for the seller, which includes both gift card donations and GAM. We might want to break this out in the future to have amounts for GAM and non-GAM gift cards (not sure the best name for the latter). This is my first time writing Ruby/RoR so feel free to give me any suggestions on my code

Trello ticket: https://trello.com/c/2Ncvuvix/609-add-gam-in-total-raised-contribution-bar-on-merchants-page

