### PR TITLE
Remove active parameter in Get All Campaigns

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -5,12 +5,7 @@ class CampaignsController < ApplicationController
 
   # GET /campaigns
   def index
-    @campaigns = if params[:active].present?
-                   valid_campaigns.order(:end_date).active(params[:active])
-                 else
-                   valid_campaigns.order(:end_date).all
-    end
-
+    @campaigns = valid_campaigns.order(:end_date).all
     json_response(campaigns_json)
   end
 

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -34,39 +34,6 @@ RSpec.describe 'Campaigns API', type: :request do
         expect(response).to have_http_status(200)
       end
     end
-
-    context 'Fetching active campaigns' do
-      before { get '/campaigns?active=true' }
-
-      it 'Returns active campaigns' do
-        expect(json).not_to be_empty
-        expect(json.size).to eq(1)
-        expect(json[0]['id']).to eq(@campaign.id)
-
-        # Has original fields
-        expect(json[0]['amount_raised']).to eq 0
-        expect(json[0]['last_contribution']).to eq nil
-        expect(json[0]['seller_id']).to eq @seller.seller_id
-      end
-
-      it 'Returns 200' do
-        expect(response).to have_http_status(200)
-      end
-    end
-
-    context 'Fetching inactive campaigns' do
-      before { get '/campaigns?active=false' }
-
-      it 'Returns inactive campaigns' do
-        expect(json).not_to be_empty
-        expect(json.size).to eq(1)
-        expect(json[0]['id']).to eq(@inactive_campaign.id)
-      end
-
-      it 'Returns 200' do
-        expect(response).to have_http_status(200)
-      end
-    end
   end
 
   context 'GET /campaigns/:id' do


### PR DESCRIPTION
I don't think we are passing in an `active` query in the get all `Campaigns` controller (from what I can see in the front end).  When would this be used? I suggest we remove this and sort the GAM campaigns on the front end. 