### PR TITLE
Allow for including broad metadata when creating a charge / payment intent

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -76,8 +76,8 @@ class ChargesController < ApplicationController
       :campaign_id,
       # TODO(justintmckibben): Deprecate this boolean in favor of campaign_id
       :is_distribution,
-      line_items: [%i[amount currency item_type quantity]],
-      :metadata
+      :metadata,
+      line_items: [%i[amount currency item_type quantity]]
     )
   end
 

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -42,7 +42,8 @@ class ChargesController < ApplicationController
                                             amount: amount,
                                             email: email,
                                             name: charge_params[:name],
-                                            line_items: line_items)
+                                            line_items: line_items,
+                                            metadata: charge_params[:metadata])
 
     # Save the contact information only if the charge is succesful
     # Use a job to avoid blocking the request
@@ -75,7 +76,8 @@ class ChargesController < ApplicationController
       :campaign_id,
       # TODO(justintmckibben): Deprecate this boolean in favor of campaign_id
       :is_distribution,
-      line_items: [%i[amount currency item_type quantity]]
+      line_items: [%i[amount currency item_type quantity]],
+      :metadata
     )
   end
 
@@ -144,7 +146,8 @@ class ChargesController < ApplicationController
     amount:,
     email:,
     name:,
-    line_items:
+    line_items:,
+    metadata:
   )
     square_location_id = if gift_a_meal? && @seller.non_profit_location_id.present?
                            @seller.non_profit_location_id
@@ -192,7 +195,8 @@ class ChargesController < ApplicationController
       receipt_url: receipt_url,
       purchaser: purchaser,
       recipient: recipient,
-      campaign: @campaign
+      campaign: @campaign,
+      metadata: metadata
     )
 
     api_response

--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -7,6 +7,7 @@
 #  id                 :bigint           not null, primary key
 #  line_items         :text
 #  lock_version       :integer
+#  metadata           :text
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null

--- a/db/migrate/20201109044231_add_metadata_to_payment_intents.rb
+++ b/db/migrate/20201109044231_add_metadata_to_payment_intents.rb
@@ -1,0 +1,5 @@
+class AddMetadataToPaymentIntents < ActiveRecord::Migration[6.0]
+  def change
+    add_column :payment_intents, :metadata, :text
+  end
+end

--- a/db/migrate/20201109044231_add_metadata_to_payment_intents.rb
+++ b/db/migrate/20201109044231_add_metadata_to_payment_intents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMetadataToPaymentIntents < ActiveRecord::Migration[6.0]
   def change
     add_column :payment_intents, :metadata, :text

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_30_031517) do
+ActiveRecord::Schema.define(version: 2020_11_09_044231) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,9 +48,9 @@ ActiveRecord::Schema.define(version: 2020_10_30_031517) do
   create_table "delivery_options", force: :cascade do |t|
     t.string "url"
     t.string "phone_number"
+    t.bigint "seller_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "seller_id", null: false
     t.index ["seller_id"], name: "index_delivery_options_on_seller_id"
   end
 
@@ -211,6 +211,7 @@ ActiveRecord::Schema.define(version: 2020_10_30_031517) do
     t.integer "lock_version"
     t.bigint "fee_id"
     t.bigint "campaign_id"
+    t.text "metadata"
     t.index ["campaign_id"], name: "index_payment_intents_on_campaign_id"
     t.index ["fee_id"], name: "index_payment_intents_on_fee_id"
     t.index ["purchaser_id"], name: "index_payment_intents_on_purchaser_id"

--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -7,6 +7,7 @@
 #  id                 :bigint           not null, primary key
 #  line_items         :text
 #  lock_version       :integer
+#  metadata           :text
 #  receipt_url        :string
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null


### PR DESCRIPTION
Background
- Items, Donation Details, etc, are only created after we receive the square webhook
- The only thing we create on a post to `/charges` is a Payment Intent
- Line Items are sent to square, which we receive back, this is how we track seller_id and project_id
- For Light-up-Chinatown (LUC) we need to store some additional information, namely a name for the lantern, and an address to possibly ship it to.

Given all of that, I don't think it makes the most sense to include it all in line items (though I'm open for discussion). I think creating an extra `metadata` property here makes the most sense.

This is a raw text field that will take and store whatever the front-end sends. For LUC we can have the frontend send structured JSON (as long as it's stringified) breaking down those properties however they like--and this field can be reused for the future for whatever other needs we might have.

Work Completed
- Migration for new `metadata` column
- Permitting and support for a `metadata` property in the POST request to `/charges`
- Simple unit test case