### PR TITLE
Make campaigns.price_per_meal nullable

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,7 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
-#  price_per_meal     :integer          default(500), not null
+#  price_per_meal     :integer          default(500)
 #  target_amount      :integer          default(100000), not null
 #  valid              :boolean          default(TRUE)
 #  created_at         :datetime         not null

--- a/db/migrate/20201112030205_change_column_on_campaigns.rb
+++ b/db/migrate/20201112030205_change_column_on_campaigns.rb
@@ -1,0 +1,5 @@
+class ChangeColumnOnCampaigns < ActiveRecord::Migration[6.0]
+  def change
+    change_column :campaigns, :price_per_meal, :integer, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_024335) do
+ActiveRecord::Schema.define(version: 2020_11_12_030205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_024335) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "distributor_id"
     t.integer "target_amount", default: 100000, null: false
-    t.integer "price_per_meal", default: 500, null: false
+    t.integer "price_per_meal", default: 500
     t.bigint "nonprofit_id"
     t.index ["distributor_id"], name: "index_campaigns_on_distributor_id"
     t.index ["location_id"], name: "index_campaigns_on_location_id"

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -9,7 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
-#  price_per_meal     :integer          default(500), not null
+#  price_per_meal     :integer          default(500)
 #  target_amount      :integer          default(100000), not null
 #  valid              :boolean          default(TRUE)
 #  created_at         :datetime         not null


### PR DESCRIPTION
Make campaigns.price_per_meal nullable. Mega GAM campaigns will not have a price_per_meal attribute

Ref: https://trello.com/c/Hj5OfLSA/692-megagam-update-campaign-model-pricepermeal-to-be-nullable