### PR TITLE
Return seller/distributor pairings for campaign

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -91,6 +91,7 @@ class CampaignsController < ApplicationController
     ret['amount_raised'] = campaign.amount_raised
     ret['last_contribution'] = campaign.last_contribution
     ret['seller_id'] = campaign.seller.seller_id
+    ret['seller_distributor_pairs'] = campaign.seller_distributor_pairs
     ret
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -55,6 +55,46 @@ class Campaign < ApplicationRecord
     ).order(created_at: :desc).first&.created_at
   end
 
+  def seller_distributor_pairs
+    pairs = []
+
+    csd_pairings = CampaignsSellersDistributor
+      .joins(:campaign)
+      .where(campaigns: {
+        id: id
+      })
+
+    seller_ids = csd_pairings.map {|pairing| pairing.seller_id}
+    sellers = Seller.where(:id => seller_ids)
+    seller_id_to_seller = {}
+    sellers.each do |seller|
+      seller_id_to_seller[seller.id] = seller
+    end
+
+    distributor_ids = csd_pairings.map {|pairing| pairing.distributor_id}
+    distributors = Distributor.where(:id => distributor_ids)
+    distributor_id_to_distributor = {}
+    distributors.each do |distributor|
+      distributor_id_to_distributor[distributor.id] = distributor
+    end
+
+    csd_pairings.each do |pairing|
+      seller = seller_id_to_seller[pairing.seller_id]
+      distributor = distributor_id_to_distributor[pairing.distributor_id]
+      pair = {
+        'distributor_id' => distributor.id,
+        'distributor_image_url' => distributor.image_url,
+        'distributor_name' => distributor.name,
+        'seller_id' => seller.id,
+        'seller_image_url' => seller.hero_image_url,
+        'seller_name' => seller.name,
+      }
+      pairs.append(pair)
+    end
+
+    pairs
+  end
+
   private
 
   # calculates the amount raised from gift cards


### PR DESCRIPTION
Return seller/distributor pairings for campaign. The return array is nested within the campaign under the 'seller_distributor_pairs' field. Each seller_distributor_pair consists of id, image_url, and name for the seller and distributor

If campaign has no seller/distributor pairings:
<img width="230" alt="Screen Shot 2020-11-11 at 8 18 41 PM" src="https://user-images.githubusercontent.com/10658691/98895261-895b0680-245b-11eb-8a7d-49aa91567fd6.png">

If campaign has pairings:
<img width="798" alt="Screen Shot 2020-11-11 at 8 18 53 PM" src="https://user-images.githubusercontent.com/10658691/98895267-8e1fba80-245b-11eb-8c54-fa35ddb9b6f8.png">

Ref: https://trello.com/c/F0FanzWN/703-megagam-update-the-campaigns-api-to-return-sellers-and-distributors-lists-pairs