### PR TITLE
Comment on payment_intents.successful

### DIFF
--- a/app/models/payment_intent.rb
+++ b/app/models/payment_intent.rb
@@ -9,6 +9,11 @@
 #  lock_version       :integer
 #  metadata           :text
 #  receipt_url        :string
+#  successful represents whether a payment has been received and processed by
+#  our system. For pooled donations and normal GAM campaigns, this means that
+#  we've created a PooledDonation, Donation, or GiftCard using the payment
+#  from Square. For Mega GAM campaigns, this means that we've received some
+#  sort of ack from Square.
 #  successful         :boolean          default(FALSE)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null


### PR DESCRIPTION
did some thinking about the payments wrt mega gam and wanted get thoughts. so right now we set the payment_intent to be successful when we create some sort of item. i think one way we can think about the payment_intent.successful field is that it represents that the payment has been acknowledged by our system, aka we've received it successfully and done what we need to do with it / square doesn't need to it through again. with this thinking, we don't need to make any changes to the existing WebhookManagers. all we need to do is set the payment_intent to be successful for payment_intents related to mega gam campaigns in the webhook controller