### PR TITLE
Add project_id to campaigns for Mega-GAM

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -17,6 +17,9 @@ class CampaignsController < ApplicationController
   # POST /campaigns
   def create
     @campaign = Campaign.create!(create_params)
+    unless @seller.present? ^ @project.present?
+      raise InvalidLineItem, "Project or Seller must exist, but not both. seller id: #{seller_id}, project_id: #{project_id}"
+    end
     json_response(campaign_json, :created)
   end
 
@@ -37,7 +40,6 @@ class CampaignsController < ApplicationController
   def create_params
     params.require(:end_date)
     params.require(:location_id)
-    params.require(:seller_id)
     params.require(:distributor_id)
 
     ret = params.permit(
@@ -47,15 +49,20 @@ class CampaignsController < ApplicationController
       :price_per_meal,
       :target_amount,
       :nonprofit_id,
+      :seller_id,
+      :project_id,
       gallery_image_urls: []
     )
 
     set_location
     set_seller
+    set_project
     set_distributor
 
     ret[:location_id] = @location.id
-    ret[:seller_id] = @seller.id
+    if @seller.present?
+      ret[:seller_id] = @seller.id
+    end
     ret[:distributor_id] = @distributor.id
 
     ret
@@ -101,7 +108,11 @@ class CampaignsController < ApplicationController
   end
 
   def set_seller
-    @seller = Seller.find_by!(seller_id: params[:seller_id])
+    @seller = Seller.find_by(seller_id: params[:seller_id])
+  end
+
+  def set_project
+    @project = Project.find_by(id: params[:project_id])
   end
 
   def set_distributor
@@ -116,7 +127,6 @@ class CampaignsController < ApplicationController
     ret = campaign.as_json
     ret['amount_raised'] = campaign.amount_raised
     ret['last_contribution'] = campaign.last_contribution
-    ret['seller_id'] = campaign.seller.seller_id
     ret['seller_distributor_pairs'] = campaign.seller_distributor_pairs
     ret
   end
@@ -124,4 +134,6 @@ class CampaignsController < ApplicationController
   def valid_campaigns
     Campaign.where(valid: true)
   end
+
+  
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -35,8 +35,10 @@
 class Campaign < ApplicationRecord
   # TODO(justintmckibben): Make the default value of valid = true
   belongs_to :location
-  belongs_to :seller
+  belongs_to :seller, optional: true
+  belongs_to :project, optional: true
   belongs_to :distributor
+  validate :has_project_xor_seller?
 
   scope :active, ->(active) { where(active: active) }
 
@@ -108,5 +110,12 @@ class Campaign < ApplicationRecord
              })
       .joins("join (#{GiftCardAmount.original_amounts_sql}) as la on la.gift_card_detail_id = gift_card_details.id")
       .sum(:value)
+  end
+
+  def has_project_xor_seller?
+    unless project.present? ^ seller.present?
+      errors.add(:project, 'Project or Seller must exist, but not both')
+      errors.add(:seller, 'Project or Seller must exist, but not both')
+    end
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -18,7 +18,7 @@
 #  distributor_id     :bigint
 #  location_id        :bigint           not null
 #  nonprofit_id       :bigint
-#  seller_id          :bigint           not null
+#  seller_id          :bigint
 #
 # Indexes
 #

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -18,6 +18,7 @@
 #  distributor_id     :bigint
 #  location_id        :bigint           not null
 #  nonprofit_id       :bigint
+#  project_id         :bigint
 #  seller_id          :bigint
 #
 # Indexes
@@ -25,11 +26,13 @@
 #  index_campaigns_on_distributor_id  (distributor_id)
 #  index_campaigns_on_location_id     (location_id)
 #  index_campaigns_on_nonprofit_id    (nonprofit_id)
+#  index_campaigns_on_project_id      (project_id)
 #  index_campaigns_on_seller_id       (seller_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (location_id => locations.id)
+#  fk_rails_...  (project_id => projects.id)
 #  fk_rails_...  (seller_id => sellers.id)
 #
 class Campaign < ApplicationRecord

--- a/app/models/seller.rb
+++ b/app/models/seller.rb
@@ -7,7 +7,6 @@
 #  id                      :bigint           not null, primary key
 #  accept_donations        :boolean          default(TRUE), not null
 #  business_type           :string
-#  business_type           :string
 #  cost_per_meal           :integer
 #  cuisine_name            :string
 #  founded_year            :integer

--- a/db/migrate/20201113001939_make_seller_id_nullable_on_campaigns.rb
+++ b/db/migrate/20201113001939_make_seller_id_nullable_on_campaigns.rb
@@ -1,0 +1,5 @@
+class MakeSellerIdNullableOnCampaigns < ActiveRecord::Migration[6.0]
+  def change
+    change_column :campaigns, :seller_id, :bigint, null: true
+  end
+end

--- a/db/migrate/20201113001940_add_project_id_to_campaigns.rb
+++ b/db/migrate/20201113001940_add_project_id_to_campaigns.rb
@@ -1,0 +1,7 @@
+class AddProjectIdToCampaigns < ActiveRecord::Migration[6.0]
+  def change
+    add_column :campaigns, :project_id, :bigint, null: true
+    add_index :campaigns, :project_id
+    add_foreign_key :campaigns, :projects
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_001939) do
+ActiveRecord::Schema.define(version: 2020_11_13_001940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,9 +30,11 @@ ActiveRecord::Schema.define(version: 2020_11_13_001939) do
     t.integer "price_per_meal", default: 500
     t.bigint "nonprofit_id"
     t.datetime "start_date"
+    t.bigint "project_id"
     t.index ["distributor_id"], name: "index_campaigns_on_distributor_id"
     t.index ["location_id"], name: "index_campaigns_on_location_id"
     t.index ["nonprofit_id"], name: "index_campaigns_on_nonprofit_id"
+    t.index ["project_id"], name: "index_campaigns_on_project_id"
     t.index ["seller_id"], name: "index_campaigns_on_seller_id"
   end
 
@@ -318,6 +320,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001939) do
   end
 
   add_foreign_key "campaigns", "locations"
+  add_foreign_key "campaigns", "projects"
   add_foreign_key "campaigns", "sellers"
   add_foreign_key "campaigns_sellers_distributors", "campaigns"
   add_foreign_key "campaigns_sellers_distributors", "distributors"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_172846) do
+ActiveRecord::Schema.define(version: 2020_11_13_001939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_172846) do
     t.string "description"
     t.string "gallery_image_urls", array: true
     t.bigint "location_id", null: false
-    t.bigint "seller_id", null: false
+    t.bigint "seller_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "distributor_id"

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -18,6 +18,7 @@
 #  distributor_id     :bigint
 #  location_id        :bigint           not null
 #  nonprofit_id       :bigint
+#  project_id         :bigint
 #  seller_id          :bigint
 #
 # Indexes
@@ -25,11 +26,13 @@
 #  index_campaigns_on_distributor_id  (distributor_id)
 #  index_campaigns_on_location_id     (location_id)
 #  index_campaigns_on_nonprofit_id    (nonprofit_id)
+#  index_campaigns_on_project_id      (project_id)
 #  index_campaigns_on_seller_id       (seller_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (location_id => locations.id)
+#  fk_rails_...  (project_id => projects.id)
 #  fk_rails_...  (seller_id => sellers.id)
 #
 require 'rails_helper'

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -36,7 +36,8 @@ require 'rails_helper'
 
 RSpec.describe Campaign, type: :model do
   it { should belong_to(:location) }
-  it { should belong_to(:seller) }
+  it { should belong_to(:seller).optional }
+  it { should belong_to(:project).optional }
   it { should belong_to(:distributor) }
 
   before { freeze_time }

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -18,7 +18,7 @@
 #  distributor_id     :bigint
 #  location_id        :bigint           not null
 #  nonprofit_id       :bigint
-#  seller_id          :bigint           not null
+#  seller_id          :bigint
 #
 # Indexes
 #

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -39,8 +39,6 @@ require 'rails_helper'
 
 RSpec.describe Campaign, type: :model do
   it { should belong_to(:location) }
-  it { should belong_to(:seller).optional }
-  it { should belong_to(:project).optional }
   it { should belong_to(:distributor) }
 
   before { freeze_time }
@@ -122,6 +120,65 @@ RSpec.describe Campaign, type: :model do
     it 'returns gift card amounts' do
       expect(campaign.amount_raised).to eq(100_00)
       expect(campaign.last_contribution).to eq(Time.current + 1.day)
+    end
+  end
+
+  let(:project) do
+    create :project
+  end
+
+  let(:seller) do
+    create :seller
+  end
+
+  context 'when creating a campaign with only a project' do
+    let(:campaign) do
+      create(:campaign, seller: nil, project: project)
+    end
+
+    it 'is successful' do
+      campaign
+    end
+  end
+
+  context 'when creating a campaign with only a seller' do
+    let(:campaign) do
+      # factory associates a seller by default
+      create :campaign
+    end
+
+    it 'is successful' do
+      campaign
+    end
+  end
+
+  context 'when creating a campaign with a project and seller' do
+    let(:campaign) do
+      Campaign.create(project: project, seller: seller)
+    end
+
+    subject { campaign }
+
+    it 'throws an error' do
+      expect(subject).to_not be_valid
+
+      expect(subject.errors[:seller]).to include('Project or Seller must exist, but not both')
+      expect(subject.errors[:project]).to include('Project or Seller must exist, but not both')
+    end
+  end
+
+  context 'when creating an campaign with neither a project nor a seller' do
+    let(:campaign) do
+      Campaign.create(project: nil, seller: nil)
+    end
+
+    subject { campaign }
+
+    it 'throws an error' do
+      expect(subject).to_not be_valid
+
+      expect(subject.errors[:project]).to include('Project or Seller must exist, but not both')
+      expect(subject.errors[:seller]).to include('Project or Seller must exist, but not both')
     end
   end
 end

--- a/spec/models/seller_spec.rb
+++ b/spec/models/seller_spec.rb
@@ -7,7 +7,6 @@
 #  id                      :bigint           not null, primary key
 #  accept_donations        :boolean          default(TRUE), not null
 #  business_type           :string
-#  business_type           :string
 #  cost_per_meal           :integer
 #  cuisine_name            :string
 #  founded_year            :integer

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -5,11 +5,13 @@ require 'rails_helper'
 RSpec.describe 'Campaigns API', type: :request do
   before do
     @seller = create :seller
+    @project = create :project
     @location = create(:location, seller_id: @seller.id)
     @campaign = create(
       :campaign,
       active: true,
       seller_id: @seller.id,
+      project_id: nil,
       location_id: @location.id
     )
   end
@@ -51,7 +53,7 @@ RSpec.describe 'Campaigns API', type: :request do
         # Has original fields
         expect(json['amount_raised']).to eq 0
         expect(json['last_contribution']).to eq nil
-        expect(json['seller_id']).to eq @seller.seller_id
+        expect(json['seller_id']).to eq @seller.id
       end
 
       it 'Returns 200' do
@@ -78,6 +80,7 @@ RSpec.describe 'Campaigns API', type: :request do
               end_date: Date.tomorrow,
               location_id: location_id,
               seller_id: seller_id,
+              project_id: project_id,
               distributor_id: distributor_id
             },
             as: :json
@@ -87,6 +90,7 @@ RSpec.describe 'Campaigns API', type: :request do
         context 'all missing ids' do
           let(:location_id) { 'missing-location-id' }
           let(:seller_id) { 'missing-seller-id' }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { 'missing-distributor-id' }
 
           it 'Returns status code 404' do
@@ -97,6 +101,7 @@ RSpec.describe 'Campaigns API', type: :request do
         context 'missing location and seller id' do
           let(:location_id) { 'missing-location-id' }
           let(:seller_id) { 'missing-seller-id' }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { distributor.id }
 
           it 'returns status code 404' do
@@ -107,6 +112,7 @@ RSpec.describe 'Campaigns API', type: :request do
         context 'missing location and distributor ids' do
           let(:location_id) { 'missing-location-id' }
           let(:seller_id) { @seller.seller_id }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { 'missing-distributor-id' }
 
           it 'returns status code 404' do
@@ -114,9 +120,10 @@ RSpec.describe 'Campaigns API', type: :request do
           end
         end
 
-        context 'missing locattion id' do
+        context 'missing location id' do
           let(:location_id) { 'missing-location-id' }
           let(:seller_id) { @seller.seller_id }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { distributor.id }
 
           it 'returns status code 404' do
@@ -127,6 +134,7 @@ RSpec.describe 'Campaigns API', type: :request do
         context 'missing seller and distributor ids' do
           let(:location_id) { @location.id }
           let(:seller_id) { 'missing-seller-id' }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { 'missing-distributor-id' }
 
           it 'returns status code 404' do
@@ -134,19 +142,21 @@ RSpec.describe 'Campaigns API', type: :request do
           end
         end
 
-        context 'missing seller id' do
+        context 'missing both seller and project ids' do
           let(:location_id) { @location.id }
           let(:seller_id) { 'missing-seller-id' }
+          let(:project_id) { 'missing-project-id' }
           let(:distributor_id) { distributor.id }
 
-          it 'returns status code 404' do
-            expect(response).to have_http_status(404)
+          it 'returns status code 422' do
+            expect(response).to have_http_status(422)
           end
         end
 
-        context 'with valid parameters' do
+        context 'with valid parameters and seller_id' do
           let(:location_id) { @location.id }
           let(:seller_id) { @seller.seller_id }
+          let(:project_id) { nil }
           let(:distributor_id) { distributor.id }
 
           it 'returns status code 201' do
@@ -163,6 +173,35 @@ RSpec.describe 'Campaigns API', type: :request do
             expect(campaign).not_to be_nil
             expect(campaign.location).to eq @location
             expect(campaign.seller).to eq @seller
+            expect(campaign.target_amount).to eq 100_000
+            expect(campaign.amount_raised).to eq 0
+            expect(campaign.price_per_meal).to eq 500
+
+            expect(campaign.active).to eq false
+            expect(campaign.valid).to eq true
+          end
+        end
+
+        context 'with valid parameters and project_id' do
+          let(:location_id) { @location.id }
+          let(:seller_id) { nil }
+          let(:project_id) { @project.id }
+          let(:distributor_id) { distributor.id }
+
+          it 'returns status code 201' do
+            expect(response).to have_http_status(201)
+          end
+
+          it 'creates a Campaign with default values and matching attributes' do
+            response_body = JSON.parse(response.body)
+            expect(response_body).not_to be_nil
+            expect(json['amount_raised']).to eq 0
+            expect(json['last_contribution']).to eq nil
+
+            campaign = Campaign.find(response_body['id'])
+            expect(campaign).not_to be_nil
+            expect(campaign.location).to eq @location
+            expect(campaign.project).to eq @project
             expect(campaign.target_amount).to eq 100_000
             expect(campaign.amount_raised).to eq 0
             expect(campaign.price_per_meal).to eq 500
@@ -212,7 +251,7 @@ RSpec.describe 'Campaigns API', type: :request do
         # Has original fields
         expect(json['amount_raised']).to eq 0
         expect(json['last_contribution']).to eq nil
-        expect(json['seller_id']).to eq @seller.seller_id
+        expect(json['seller_id']).to eq @seller.id
       end
 
       it 'Updates the fields in the record' do

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -153,6 +153,17 @@ RSpec.describe 'Campaigns API', type: :request do
           end
         end
 
+        context 'missing both seller and project ids' do
+          let(:location_id) { @location.id }
+          let(:seller_id) { @seller.seller_id }
+          let(:project_id) { @project.id }
+          let(:distributor_id) { distributor.id }
+
+          it 'returns status code 422' do
+            expect(response).to have_http_status(422)
+          end
+        end
+
         context 'with valid parameters and seller_id' do
           let(:location_id) { @location.id }
           let(:seller_id) { @seller.seller_id }
@@ -177,8 +188,8 @@ RSpec.describe 'Campaigns API', type: :request do
             expect(campaign.amount_raised).to eq 0
             expect(campaign.price_per_meal).to eq 500
 
-            expect(campaign.active).to eq false
-            expect(campaign.valid).to eq true
+            expect(campaign.active).to be false
+            expect(campaign.valid).to be true
           end
         end
 
@@ -206,8 +217,8 @@ RSpec.describe 'Campaigns API', type: :request do
             expect(campaign.amount_raised).to eq 0
             expect(campaign.price_per_meal).to eq 500
 
-            expect(campaign.active).to eq false
-            expect(campaign.valid).to eq true
+            expect(campaign.active).to be false
+            expect(campaign.valid).to be true
           end
         end
       end


### PR DESCRIPTION
Add project_id and make seller_id optional for campaigns, such that project_id xor seller_id must exist for a campaign.

This was added to allow us to associate a GAM campaign with a project which will be used by Mega-GAM