### PR TITLE
Add/update methods on campaign model to get amount allocated/raised for mega GAM campaigns

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -115,6 +115,7 @@ class CampaignsController < ApplicationController
   def campaign_json(campaign: @campaign)
     ret = campaign.as_json
     ret['amount_raised'] = campaign.amount_raised
+    ret['amount_allocated'] = campaign.amount_allocated
     ret['last_contribution'] = campaign.last_contribution
     ret['seller_id'] = campaign.seller.seller_id
     ret['seller_distributor_pairs'] = campaign.seller_distributor_pairs

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -112,18 +112,17 @@ class Campaign < ApplicationRecord
   private
 
   def mega_gam?
-    project_id != nil
+    project.present?
   end
 
   # Calculates the amount raised in the payment intent table.
   def payment_intent_amount
-    # TODO CHECK SYNTAX
     PaymentIntent
       .joins(:campaign)
       .where(campaigns: {
         campaign_id: id
       })
-      .map {$.amount}
+      .map { |payment_intent| payment_intent.amount }
       .sum
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -126,7 +126,10 @@ class Campaign < ApplicationRecord
   def payment_intent_amount
     PaymentIntent
       .joins(:campaign)
-      .where('campaigns.id=? AND successful=true', id)
+      .where(campaigns: {
+        id: id,
+      })
+      .where(successful: true)
       .map { |payment_intent| payment_intent.amount }
       .sum
   end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -120,9 +120,10 @@ class Campaign < ApplicationRecord
     PaymentIntent
       .joins(:campaign)
       .where(campaigns: {
-        id: id
+        campaign_id: id
       })
-      .sum(:line_items.value)
+      .map {$.amount}
+      .sum
   end
 
   # calculates the amount raised from gift cards

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -42,6 +42,7 @@ class Campaign < ApplicationRecord
   belongs_to :project, optional: true
   belongs_to :distributor
   has_many :campaigns_sellers_distributors
+  has_many :payment_intent
   validate :has_project_xor_seller?
 
   scope :active, ->(active) { where(active: active) }
@@ -125,9 +126,7 @@ class Campaign < ApplicationRecord
   def payment_intent_amount
     PaymentIntent
       .joins(:campaign)
-      .where(campaigns: {
-        campaign_id: id
-      })
+      .where('campaigns.id=? AND successful=true', id)
       .map { |payment_intent| payment_intent.amount }
       .sum
   end

--- a/spec/factories/campaign.rb
+++ b/spec/factories/campaign.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
         FactoryBot.create :campaigns_sellers_distributor, campaign_id: campaign.id
       end
     end
+
+    trait :with_project do
+      association :project
+    end
   end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Campaign, type: :model do
         value: 50_00,
         gift_card_detail: gift_card_detail1
       )
-  
+
       # Create second gift card, which is a $50 gift card with $20 spent
       item_gift_card2 = create(
         :item,
@@ -102,7 +102,7 @@ RSpec.describe Campaign, type: :model do
         value: 50_00,
         gift_card_detail: gift_card_detail2
       )
-  
+
       # Create $100 gift card, refunded
       item_gift_card3 = create(
         :item,
@@ -124,14 +124,16 @@ RSpec.describe Campaign, type: :model do
   
   context 'with amount raised for mega gam campaigns' do
     let!(:campaign) { create(:campaign, :with_sellers_distributors, :with_project, seller: nil) }
-
-    it 'returns payment intent amounts' do
+    subject do 
       # Expect these 2 to be counted. :with_line_items adds line items of value 600.
       payment_intent_1 = create(:payment_intent, :with_line_items, campaign: campaign, successful: true)
       payment_intent_2 = create(:payment_intent, :with_line_items, campaign: campaign, successful: true)
       # Do not expect this one to be counted since it's not successful.
       payment_intent_3 = create(:payment_intent, :with_line_items, campaign: campaign, successful: false)
+    end
 
+    it 'returns payment intent amounts' do
+      subject 
       expect(campaign.amount_raised).to eq 1200
     end
   end


### PR DESCRIPTION
Add/update methods on campaign model to get amount allocated/raised for mega GAM campaigns

Ref: https://trello.com/c/G6DvJnWK/705-megagam-create-allocatedamount-calculated-field-for-mega-gam and https://trello.com/c/HGoRxNWg/704-megagam-create-totaldonationamount-calculated-field-for-mega-gam