### PR TITLE
Add new migration to revert non null attribute on delivery_type_id

### DIFF
--- a/db/migrate/20201118030655_revert_non_null_delivery_type_id.rb
+++ b/db/migrate/20201118030655_revert_non_null_delivery_type_id.rb
@@ -1,0 +1,5 @@
+class RevertNonNullDeliveryTypeId < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:delivery_options, :delivery_type_id, true)
+  end
+end


### PR DESCRIPTION
Removed `NOT NULL` on the `delivery_option.delivery_type_id` since it broke staging