### PR TITLE
Fix seller_id in campaign api response

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -128,6 +128,7 @@ class CampaignsController < ApplicationController
     ret['amount_raised'] = campaign.amount_raised
     ret['amount_allocated'] = campaign.amount_allocated
     ret['last_contribution'] = campaign.last_contribution
+    ret['seller_id'] = campaign.seller.nil? ? "" : campaign.seller.seller_id
     ret['seller_distributor_pairs'] = campaign.seller_distributor_pairs
     ret
   end

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'Campaigns API', type: :request do
         # Has original fields
         expect(json['amount_raised']).to eq 0
         expect(json['last_contribution']).to eq nil
-        expect(json['seller_id']).to eq @seller.id
+        expect(json['seller_id']).to eq @seller.seller_id
       end
 
       it 'Returns 200' do
@@ -292,7 +292,7 @@ RSpec.describe 'Campaigns API', type: :request do
         # Has original fields
         expect(json['amount_raised']).to eq 0
         expect(json['last_contribution']).to eq nil
-        expect(json['seller_id']).to eq @seller.id
+        expect(json['seller_id']).to eq @seller.seller_id
       end
 
       it 'Updates the fields in the record' do


### PR DESCRIPTION
GAM campaigns frontend is broken when trying at `getSeller` because we made `seller_id` an int (seller.id) instead of the string (seller_id) in the Campaigns api response in this PR: https://github.com/sendchinatownlove/ruby/pull/286