### PR TITLE
Add 'transaction_fee' as valid line item type

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -97,9 +97,9 @@ class ChargesController < ApplicationController
         end
       end
 
-      unless %w[gift_card donation].include? line_item['item_type']
+      unless %w[gift_card donation transaction_fee].include? line_item['item_type']
         raise InvalidLineItem,
-              'line_item must be named `gift_card` or `donation`'
+              'line_item must be named `gift_card`, `donation`, or `transaction_fee`'
       end
 
       unless line_item['amount'].is_a? Integer

--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe 'Charges API', type: :request do
 
       it 'returns a validation failure message' do
         expect(response.body).to match(
-          /line_item must be named `gift_card` or `donation`/
+          /line_item must be named `gift_card`, `donation`, or `transaction_fee`/
         )
       end
     end


### PR DESCRIPTION
- Adds `transaction_fee` as a valid line_item `item_type`.

Example charges payload with transaction fee:

```javascript
{
  ...,
  line_items: [
    { amount: 10000, currency: "usd", item_type: "donation", quantity: 1 },
    { amount: 314, currency: "usd", item_type: "transaction_fee", quantity: 1 }
  ]
}
```

