### PR TITLE
Fix charges_controller amount validation to use total

### DIFF
--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -626,13 +626,20 @@ RSpec.describe 'Charges API', type: :request do
       end
     end
 
-    context 'with $.49 in the amount' do
+    context 'with total amount too small' do
       let(:line_items) do
         [
           {
-            amount: 49,
+            amount: 39,
             currency: 'usd',
             item_type: 'gift_card',
+            quantity: 1,
+            seller_id: seller_id
+          },
+          {
+            amount: 10,
+            currency: 'usd',
+            item_type: 'transaction_fee',
             quantity: 1,
             seller_id: seller_id
           }

--- a/spec/requests/charges_spec.rb
+++ b/spec/requests/charges_spec.rb
@@ -626,7 +626,7 @@ RSpec.describe 'Charges API', type: :request do
       end
     end
 
-    context 'with total amount too small' do
+    context 'with total amount below minimum' do
       let(:line_items) do
         [
           {


### PR DESCRIPTION
This branch changes the 'amount' validation in `charges_controller#validate` to look at total amount instead of each line_item amount when validating for minimum amount.

Clears blocker to transaction fee frontend branch.