### PR TITLE
Wilson/past campaign pagination

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -17,9 +17,11 @@ class CampaignsController < ApplicationController
 
       json_response(@records)
     else
-      @campaigns = valid_campaigns.order(:end_date).all
+      query = valid_campaigns.order(:end_date).all
 
-      json_response(campaigns_json)
+      @pagy, @records = pagy(query)
+
+      json_response(@records)
     end
   end
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,12 +1,23 @@
 # frozen_string_literal: true
+include Pagy::Backend
 
 class CampaignsController < ApplicationController
   before_action :set_campaign, only: %i[show update]
+  after_action { pagy_headers_merge(@pagy) if @pagy }
 
   # GET /campaigns
   def index
     @campaigns = valid_campaigns.order(:end_date).all
     json_response(campaigns_json)
+  end
+
+  # GET /campaigns/inactive
+  def index_past_campaigns
+    query = past_campaigns.order(:end_date).all
+
+    @pagy, @records = pagy(query)
+
+    json_response(@records)
   end
 
   # GET /campaigns/:id
@@ -134,5 +145,9 @@ class CampaignsController < ApplicationController
 
   def valid_campaigns
     Campaign.where(valid: true)
+  end
+
+  def past_campaigns
+    Campaign.where({valid: true, active: false})
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -7,17 +7,20 @@ class CampaignsController < ApplicationController
 
   # GET /campaigns
   def index
-    @campaigns = valid_campaigns.order(:end_date).all
-    json_response(campaigns_json)
-  end
+    # @NOTE(wilson) check to see if querying for inactive campaigns
+    # otherwise return active campaigns by default
+    inactive = params[:inactive]
+    if inactive == 'true'
+      query = past_campaigns.order(:end_date).all
 
-  # GET /campaigns/inactive
-  def index_past_campaigns
-    query = past_campaigns.order(:end_date).all
+      @pagy, @records = pagy(query)
 
-    @pagy, @records = pagy(query)
+      json_response(@records)
+    else
+      @campaigns = valid_campaigns.order(:end_date).all
 
-    json_response(@records)
+      json_response(campaigns_json)
+    end
   end
 
   # GET /campaigns/:id
@@ -144,7 +147,7 @@ class CampaignsController < ApplicationController
   end
 
   def valid_campaigns
-    Campaign.where(valid: true)
+    Campaign.where({valid: true, active: true})
   end
 
   def past_campaigns

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -11,17 +11,15 @@ class CampaignsController < ApplicationController
     # otherwise return active campaigns by default
     inactive = params[:inactive]
     if inactive == 'true'
-      query = past_campaigns.order(:end_date).all
+      @campaigns = past_campaigns.order('end_date desc').all
 
-      @pagy, @records = pagy(query)
-
-      json_response(@records)
+      @pagy, @records = pagy(@campaigns)
+      json_response(campaigns_records_json)
     else
-      query = valid_campaigns.order(:end_date).all
+      @campaigns = valid_campaigns.order(:end_date).all
 
-      @pagy, @records = pagy(query)
-
-      json_response(@records)
+      @pagy, @records = pagy(@campaigns)
+      json_response(campaigns_records_json)
     end
   end
 
@@ -138,6 +136,10 @@ class CampaignsController < ApplicationController
     @campaigns.map { |c| campaign_json campaign: c }
   end
 
+  def campaigns_records_json(record: @records)
+    record.map { |c| campaign_json campaign: c }
+  end
+
   def campaign_json(campaign: @campaign)
     ret = campaign.as_json
     ret['amount_raised'] = campaign.amount_raised
@@ -149,10 +151,10 @@ class CampaignsController < ApplicationController
   end
 
   def valid_campaigns
-    Campaign.where({valid: true, active: true})
+    Campaign.where(valid: true)
   end
 
   def past_campaigns
-    Campaign.where({valid: true, active: false})
+    Campaign.where(valid: true, active: false)
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -9,8 +9,8 @@ class CampaignsController < ApplicationController
   def index
     # @NOTE(wilson) check to see if querying for inactive campaigns
     # otherwise return active campaigns by default
-    inactive = params[:inactive]
-    if inactive == 'true'
+    inactive = ActiveModel::Type::Boolean.new.cast(params[:inactive])
+    if inactive == true
       @campaigns = past_campaigns.order('end_date desc').all
 
       @pagy, @records = pagy(@campaigns)

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -14,12 +14,12 @@ class CampaignsController < ApplicationController
       @campaigns = past_campaigns.order('end_date desc').all
 
       @pagy, @records = pagy(@campaigns)
-      json_response(campaigns_records_json)
+      json_response(campaigns_json(@records))
     else
       @campaigns = valid_campaigns.order(:end_date).all
 
       @pagy, @records = pagy(@campaigns)
-      json_response(campaigns_records_json)
+      json_response(campaigns_json(@records))
     end
   end
 
@@ -132,12 +132,8 @@ class CampaignsController < ApplicationController
     @distributor = Distributor.find(params[:distributor_id])
   end
 
-  def campaigns_json
-    @campaigns.map { |c| campaign_json campaign: c }
-  end
-
-  def campaigns_records_json(record: @records)
-    record.map { |c| campaign_json campaign: c }
+  def campaigns_json(campaigns =  @campaigns)
+    campaigns.map { |c| campaign_json campaign: c }
   end
 
   def campaign_json(campaign: @campaign)
@@ -151,7 +147,7 @@ class CampaignsController < ApplicationController
   end
 
   def valid_campaigns
-    Campaign.where(valid: true)
+    Campaign.where(valid: true, active: true)
   end
 
   def past_campaigns

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -132,10 +132,13 @@ class Campaign < ApplicationRecord
     {
       'distributor_id' => distributor.id,
       'distributor_image_url' => distributor.image_url,
+      'distributor_website_url' => distributor.website_url,
       'distributor_name' => distributor.name,
       'seller_id' => seller.seller_id,
+      'seller_non_profit_location_id' => seller.non_profit_location_id,
       'seller_image_url' => seller.hero_image_url,
-      'seller_name' => seller.name
+      'seller_name' => seller.name,
+      'seller_city' => seller.locations.size > 0 ? seller.locations.first.city : nil
     }
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -22,6 +22,10 @@ Rails.application.configure do
     allow do
       origins 'localhost:3000', '127.0.0.1:3000',
               'localhost:4000', '127.0.0.1:4000'
+      resource '/campaigns',
+        methods: [:get],
+        headers: :any,
+        expose: ['Total-Count', 'Total-Pages', 'Page-Items', 'Current-Page']
       resource '*', headers: :any, methods: :any
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,8 +22,11 @@ Rails.application.configure do
         'https://sendchinatownlove.github.io',
         'https://www.sendchinatownlove.github.io'
       )
-      resource '*', headers: :any, methods: :any
-    end
+      resource '/campaigns',
+        methods: [:get],
+        headers: :any,
+        expose: ['Total-Count', 'Total-Pages', 'Page-Items', 'Current-Page']
+      resource '*', headers: :any, methods: :any    end
   end
 
   # Full error reports are disabled and caching is turned on.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -23,6 +23,10 @@ Rails.application.configure do
               'https://staging-scl.netlify.app',
               'https://www.staging-scl.netlify.app'
 
+      resource '/campaigns',
+        methods: [:get],
+        headers: :any,
+        expose: ['Total-Count', 'Total-Pages', 'Page-Items', 'Current-Page']
       resource '*', headers: :any, methods: :any
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   resources :nonprofits
   post 'contacts/:contact_id/lyft_rewards/:token/redeem', to: 'contact_lyft_rewards#redeem'
   post 'campaigns/:id/seller_distributor', action: :associate_seller_distributor, controller: 'campaigns'
+  get 'campaigns/inactive', to: 'campaigns#index_past_campaigns'
 
   resources :campaigns do
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,6 @@ Rails.application.routes.draw do
   resources :nonprofits
   post 'contacts/:contact_id/lyft_rewards/:token/redeem', to: 'contact_lyft_rewards#redeem'
   post 'campaigns/:id/seller_distributor', action: :associate_seller_distributor, controller: 'campaigns'
-  get 'campaigns/inactive', to: 'campaigns#index_past_campaigns'
 
   resources :campaigns do
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -192,24 +192,22 @@ end
 
 [
   {
+    name: 'Fee 1',
     active: true,
     multiplier: 0.1,
-    seller_id: '46-mott'
   },
   {
+    name: 'Fee 2',
     active: true,
     multiplier: 0.1,
-    seller_id: '46-mott'
   },
   {
+    name: 'Fee 3',
     active: false,
     multiplier: 0.1,
-    seller_id: 'shunfa-bakery'
   }
 ].each do |attributes|
-  seller = Seller.find_by(seller_id: attributes[:seller_id])
   fee_attributes = attributes.except(:seller_id)
-  fee_attributes[:seller_id] = seller.id
   Fee.create!(fee_attributes)
 end
 
@@ -219,11 +217,11 @@ distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com'
 location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborhood: 'Chinatown', state: 'NY', zip_code: '12345')
 (0..20).each do |i|
   if i == 0
-Campaign.create(
-  seller_id: seller.id,
-  distributor: distributor,
-  location: location,
-  active: true,
+    Campaign.create(
+      seller_id: seller.id,
+      distributor: distributor,
+      location: location,
+      active: true,
       end_date: Time.now + 30.days,
       gallery_image_urls: [
         "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -233,7 +233,7 @@ location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborh
       distributor: distributor,
       location: location,
       active: false,
-      end_date: Time.now - 30.days,
+      end_date: Time.now - 30.days - i.days,
       gallery_image_urls: [
         "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
       ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -217,13 +217,31 @@ seller = Seller.find_by(seller_id: 'shunfa-bakery')
 contact = Contact.find_or_create_by!(name: 'Apex for Youth', email: 'distributor@apexforyouth.com')
 distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com', website_url: 'apexforyouth.com', name: 'Apex for Youth'
 location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborhood: 'Chinatown', state: 'NY', zip_code: '12345')
+(0..20).each do |i|
+  if i == 0
 Campaign.create(
   seller_id: seller.id,
   distributor: distributor,
   location: location,
   active: true,
-  end_date: Time.now + 30.days
-)
+      end_date: Time.now + 30.days,
+      gallery_image_urls: [
+        "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
+      ]
+    )
+  else
+    Campaign.create(
+      seller_id: seller.id,
+      distributor: distributor,
+      location: location,
+      active: false,
+      end_date: Time.now - 30.days,
+      gallery_image_urls: [
+        "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
+      ]
+    )
+  end
+end
 
 [
   {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -213,7 +213,7 @@ end
 
 seller = Seller.find_by(seller_id: 'shunfa-bakery')
 contact = Contact.find_or_create_by!(name: 'Apex for Youth', email: 'distributor@apexforyouth.com')
-distributor = Distributor.create contact: contact, image_url: 'apexforyouth.com', website_url: 'apexforyouth.com', name: 'Apex for Youth'
+distributor = Distributor.create contact: contact, image_url: 'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/apex-for-youth/apex-for-youth-logo.png', website_url: 'apexforyouth.com', name: 'Apex for Youth'
 location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborhood: 'Chinatown', state: 'NY', zip_code: '12345')
 (0..20).each do |i|
   if i == 0
@@ -225,7 +225,8 @@ location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborh
       end_date: Time.now + 30.days,
       gallery_image_urls: [
         "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
-      ]
+      ],
+      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc orci nisi, commodo vitae egestas a, laoreet sit amet elit. Sed enim ligula, ultricies a lectus a, faucibus scelerisque nisl. In at magna volutpat, auctor libero nec, sagittis nibh. Quisque vitae convallis elit. Curabitur facilisis auctor libero at accumsan. Morbi a nisi urna. Pellentesque augue nibh, ultricies a feugiat quis, fermentum nec orci. Vestibulum libero sem, vulputate id ligula eget, auctor lobortis diam. Etiam ullamcorper ex eu condimentum sodales. Fusce vel semper augue. Etiam placerat luctus ex, nec ultrices enim ornare id. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Donec iaculis est purus, non pellentesque erat suscipit vitae.'
     )
   else
     Campaign.create(

--- a/spec/factories/campaign.rb
+++ b/spec/factories/campaign.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
       after(:create) do |campaign, _index|
         FactoryBot.create :campaigns_sellers_distributor, campaign_id: campaign.id
         FactoryBot.create :campaigns_sellers_distributor, campaign_id: campaign.id
+        if campaign.seller != nil
+          create_list(:location, 1, seller_id: campaign.seller.id)
+        end
+
       end
     end
 

--- a/spec/factories/campaigns_sellers_distributor.rb
+++ b/spec/factories/campaigns_sellers_distributor.rb
@@ -2,8 +2,11 @@
 
 FactoryBot.define do
   factory :campaigns_sellers_distributor do
+    transient do
+      with_seller_location { false }
+    end
     association :campaign
     association :distributor
-    association :seller
+    association :seller, factory: :seller_with_location
   end
 end

--- a/spec/factories/seller.rb
+++ b/spec/factories/seller.rb
@@ -40,5 +40,12 @@ FactoryBot.define do
         campaign = FactoryBot.create :campaign, seller_id: s.id, distributor: distributor, active: true
       end
     end
+
+    # Factory for has_many association for sellers with locations
+    factory :seller_with_location do
+      after(:create) do |seller|
+        create_list(:location, 1, seller_id: seller.id)
+      end
+    end
   end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -166,21 +166,26 @@ RSpec.describe Campaign, type: :model do
       pairs = [{
         'distributor_id' => campaign.distributor.id,
         'distributor_image_url' => campaign.distributor.image_url,
+        'distributor_website_url' => campaign.distributor.website_url,
         'distributor_name' => campaign.distributor.name,
         'seller_id' => campaign.seller.seller_id,
+        'seller_non_profit_location_id' => campaign.seller.non_profit_location_id,
         'seller_image_url' => campaign.seller.hero_image_url,
-        'seller_name' => campaign.seller.name
+        'seller_name' => campaign.seller.name,
+        'seller_city' => campaign.seller.locations.first.city
       }]
-
       # Inserts seller/dist pairs
       csds.each do |csd|
         pairs << {
           'distributor_id' => csd.distributor.id,
           'distributor_image_url' => csd.distributor.image_url,
+          'distributor_website_url' => csd.distributor.website_url,
           'distributor_name' => csd.distributor.name,
           'seller_id' => csd.seller.seller_id,
+          'seller_non_profit_location_id' => csd.seller.non_profit_location_id,
           'seller_image_url' => csd.seller.hero_image_url,
-          'seller_name' => csd.seller.name
+          'seller_name' => csd.seller.name,
+          'seller_city' => csd.seller.locations.first.city
         }
       end
 

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -19,9 +19,19 @@ RSpec.describe 'Campaigns API', type: :request do
       location_id: @location.id
     )
   end
+  let!(:inactive_campaign) do
+    create_list(
+      :campaign,
+      2,
+      seller_id: @seller.id,
+      project_id: nil,
+      location_id: @location.id,
+      active: false
+    )
+  end
 
   context 'GET /campaigns' do
-    context 'Fetching all campaigns' do
+    context 'Fetching all active campaigns' do
       subject { get '/campaigns' }
 
       it 'Returns campaigns' do
@@ -35,23 +45,9 @@ RSpec.describe 'Campaigns API', type: :request do
         expect(response).to have_http_status(200)
       end
     end
-  end
-
-  context 'GET /campaigns/inactive' do
-    # @NOTE(wilson)Test setup for inactive campaigns route
-    let!(:inactive_campaign) do
-      create_list(
-        :campaign,
-        2,
-        seller_id: @seller.id,
-        project_id: nil,
-        location_id: @location.id,
-        active: false
-      )
-    end
 
     context 'with some basic pagination' do
-      subject { get '/campaigns/inactive'}
+      subject { get '/campaigns/?inactive=true'}
       it 'returns 2 records with default pagination' do
         subject
         expect(json).not_to be_empty
@@ -59,7 +55,7 @@ RSpec.describe 'Campaigns API', type: :request do
       end
 
       it 'returns 1 record and the first page when querying for one page' do
-        get '/campaigns/inactive/?items=1'
+        get '/campaigns/?inactive=true&items=1'
         expect(json).not_to be_empty
         expect(json.size).to eq 1
 
@@ -69,7 +65,7 @@ RSpec.describe 'Campaigns API', type: :request do
       end
 
       it 'returns 1 record and two pages when querying for page 2' do
-        get '/campaigns/inactive/?page=2&items=1'
+        get '/campaigns/?inactive=true&page=2&items=1'
         expect(json).not_to be_empty
         expect(json.size).to eq 1
 

--- a/spec/requests/campaigns_request_spec.rb
+++ b/spec/requests/campaigns_request_spec.rb
@@ -37,6 +37,49 @@ RSpec.describe 'Campaigns API', type: :request do
     end
   end
 
+  context 'GET /campaigns/inactive' do
+    # @NOTE(wilson)Test setup for inactive campaigns route
+    let!(:inactive_campaign) do
+      create_list(
+        :campaign,
+        2,
+        seller_id: @seller.id,
+        project_id: nil,
+        location_id: @location.id,
+        active: false
+      )
+    end
+
+    context 'with some basic pagination' do
+      subject { get '/campaigns/inactive'}
+      it 'returns 2 records with default pagination' do
+        subject
+        expect(json).not_to be_empty
+        expect(json.size).to eq 2
+      end
+
+      it 'returns 1 record and the first page when querying for one page' do
+        get '/campaigns/inactive/?items=1'
+        expect(json).not_to be_empty
+        expect(json.size).to eq 1
+
+        expect(response.headers['Current-Page'].to_i).to eq 1
+        expect(response.headers['Total-Pages'].to_i).to eq 2
+        expect(response.headers['Total-Count'].to_i).to eq 2
+      end
+
+      it 'returns 1 record and two pages when querying for page 2' do
+        get '/campaigns/inactive/?page=2&items=1'
+        expect(json).not_to be_empty
+        expect(json.size).to eq 1
+
+        expect(response.headers['Current-Page'].to_i).to eq 2
+        expect(response.headers['Total-Pages'].to_i).to eq 2
+        expect(response.headers['Total-Count'].to_i).to eq 2
+      end
+    end
+  end
+
   context 'GET /campaigns/:id' do
     subject { get "/campaigns/#{campaign_id}" }
 


### PR DESCRIPTION
Update `GET /campaigns` so it accepts query params and so it paginates the response. By default it returns all active campaigns, but you can add `?inactive=true` to the endpoint to fetch all inactive campaigns.

And then you can request paginated data through the standard Pagy query params 

![image](https://user-images.githubusercontent.com/12119553/101071593-d28a0c00-356a-11eb-9231-00678bfee46e.png)


NOTE: Updated the campaigns test/ test rigs and am not sure if it's super wonky or not
