### PR TITLE
removed is_distribution and updated campaign_id fields

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -19,7 +19,8 @@ class ChargesController < ApplicationController
     validate(
       seller_id: seller_id,
       project_id: project_id,
-      line_items: line_items
+      line_items: line_items,
+      is_distribution: charge_params[:is_distribution]
     )
 
     # Validate each Item and get all ItemTypes
@@ -74,12 +75,14 @@ class ChargesController < ApplicationController
       :idempotency_key,
       :is_subscribed,
       :campaign_id,
+      # TODO(justintmckibben): Deprecate this boolean in favor of campaign_id
+      :is_distribution,
       :metadata,
       line_items: [%i[amount currency item_type quantity]]
     )
   end
 
-  def validate(seller_id:, project_id:, line_items:)
+  def validate(seller_id:, project_id:, line_items:, is_distribution:)
     @seller = Seller.find_by(seller_id: seller_id)
     @project = Project.find_by(id: project_id)
 
@@ -108,9 +111,9 @@ class ChargesController < ApplicationController
         raise InvalidLineItem, 'line_item.quantity must be an Integer'
       end
 
-      @campaign = if charge_params[:campaign_id].present? && !project_id.present?
-                    # TODO(billyyuan): Replace !project_id.present? once a mega gam is defined by having multi-sellers
-                    #                  Currently, a mega gam is defined by whether a campaign_id and project_id exists
+      @campaign = if is_distribution.present?
+                    # TODO(justintmckibben): Delete this case when we start using campaign_id
+                    #                        in the frontend
                     campaign = Campaign.find_by(
                       seller_id: @seller.id,
                       active: true,
@@ -122,7 +125,7 @@ class ChargesController < ApplicationController
 
                     campaign
                   elsif charge_params[:campaign_id].present?
-                    Campaign.find_by(id: charge_params[:campaign_id])
+                    Campaign.find(charge_params[:campaign_id])
                   end
 
       amount = line_item['amount']
@@ -152,10 +155,10 @@ class ChargesController < ApplicationController
     metadata:,
     project_id:
   )
-    square_location_id = if @project.present?
-                           @project.square_location_id
-                         elsif gift_a_meal? && @seller.non_profit_location_id.present?
+    square_location_id = if gift_a_meal? && @seller.present? && @seller.non_profit_location_id.present?
                            @seller.non_profit_location_id
+                         elsif @project.present?
+                           @project.square_location_id
                          else
                            @seller.square_location_id
                          end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,6 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
+#  neighborhood       :string
 #  price_per_meal     :integer          default(500)
 #  start_date         :datetime
 #  target_amount      :integer          default(100000), not null
@@ -17,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  distributor_id     :bigint
 #  fee_id             :integer
-#  location_id        :bigint           not null
+#  location_id        :bigint
 #  nonprofit_id       :bigint
 #  project_id         :bigint
 #  seller_id          :bigint

--- a/db/migrate/20201213190758_add_neighborhood_to_campaign.rb
+++ b/db/migrate/20201213190758_add_neighborhood_to_campaign.rb
@@ -1,0 +1,12 @@
+class AddNeighborhoodToCampaign < ActiveRecord::Migration[6.0]
+  def change
+    add_column :campaigns, :neighborhood, :string
+
+    # Get all of the current campaigns and fill the neighborhood
+    Campaign.all.each do |c|
+      c.update(neighborhood: c.location.neighborhood)
+    end
+
+    change_column :campaigns, :location_id, :bigint, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_001940) do
+ActiveRecord::Schema.define(version: 2020_12_13_190758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001940) do
     t.datetime "end_date", null: false
     t.string "description"
     t.string "gallery_image_urls", array: true
-    t.bigint "location_id", null: false
+    t.bigint "location_id"
     t.bigint "seller_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001940) do
     t.bigint "nonprofit_id"
     t.datetime "start_date"
     t.bigint "project_id"
+    t.string "neighborhood"
     t.index ["distributor_id"], name: "index_campaigns_on_distributor_id"
     t.index ["location_id"], name: "index_campaigns_on_location_id"
     t.index ["nonprofit_id"], name: "index_campaigns_on_nonprofit_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -417,3 +417,16 @@ end
 ].each do |attributes|
   Project.find_or_create_by(name: attributes[:name]).update!(attributes)
 end
+
+# Create a mega gam campaign
+megagam_project = Project.create!(name: 'mega gam', square_location_id: ENV['SQUARE_LOCATION_ID']);
+Campaign.create(
+  project_id: megagam_project[:id],
+  distributor: distributor,
+  gallery_image_urls: [
+    "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
+  ],
+  location: location,
+  active: true,
+  end_date: Time.now + 30.days
+)

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -9,6 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
+#  neighborhood       :string
 #  price_per_meal     :integer          default(500)
 #  start_date         :datetime
 #  target_amount      :integer          default(100000), not null
@@ -17,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  distributor_id     :bigint
 #  fee_id             :integer
-#  location_id        :bigint           not null
+#  location_id        :bigint
 #  nonprofit_id       :bigint
 #  project_id         :bigint
 #  seller_id          :bigint


### PR DESCRIPTION
I removed the `is_distribution` field and updated the `campaign_id` fields.

Would like a review to make sure my changes below align with the current business logic.

Lines refer to my diff:
- Line 111: If a campaign but a project doesnt exist, then process as a regular gam
- Lines 157-158: If a project exists, then square location id will be equal to the location id of the project

Once these changes are good to go, the front end mega gam checkout should be ready to be pushed as well since I've tested a mega gam payment and see my test transactions show up in the payment_intents table with a project ID and campaign ID. More than happy to do more testing though.