### PR TITLE
Add neighborhood to campaign in favor of location

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -9,6 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
+#  neighborhood       :string
 #  price_per_meal     :integer          default(500)
 #  start_date         :datetime
 #  target_amount      :integer          default(100000), not null
@@ -17,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  distributor_id     :bigint
 #  fee_id             :integer
-#  location_id        :bigint           not null
+#  location_id        :bigint
 #  nonprofit_id       :bigint
 #  project_id         :bigint
 #  seller_id          :bigint

--- a/db/migrate/20201213190758_add_neighborhood_to_campaign.rb
+++ b/db/migrate/20201213190758_add_neighborhood_to_campaign.rb
@@ -1,0 +1,12 @@
+class AddNeighborhoodToCampaign < ActiveRecord::Migration[6.0]
+  def change
+    add_column :campaigns, :neighborhood, :string
+
+    # Get all of the current campaigns and fill the neighborhood
+    Campaign.all.each do |c|
+      c.update(neighborhood: c.location.neighborhood)
+    end
+
+    change_column :campaigns, :location_id, :bigint, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_001940) do
+ActiveRecord::Schema.define(version: 2020_12_13_190758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001940) do
     t.datetime "end_date", null: false
     t.string "description"
     t.string "gallery_image_urls", array: true
-    t.bigint "location_id", null: false
+    t.bigint "location_id"
     t.bigint "seller_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_001940) do
     t.bigint "nonprofit_id"
     t.datetime "start_date"
     t.bigint "project_id"
+    t.string "neighborhood"
     t.index ["distributor_id"], name: "index_campaigns_on_distributor_id"
     t.index ["location_id"], name: "index_campaigns_on_location_id"
     t.index ["nonprofit_id"], name: "index_campaigns_on_nonprofit_id"

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -9,6 +9,7 @@
 #  description        :string
 #  end_date           :datetime         not null
 #  gallery_image_urls :string           is an Array
+#  neighborhood       :string
 #  price_per_meal     :integer          default(500)
 #  start_date         :datetime
 #  target_amount      :integer          default(100000), not null
@@ -17,7 +18,7 @@
 #  updated_at         :datetime         not null
 #  distributor_id     :bigint
 #  fee_id             :integer
-#  location_id        :bigint           not null
+#  location_id        :bigint
 #  nonprofit_id       :bigint
 #  project_id         :bigint
 #  seller_id          :bigint


### PR DESCRIPTION
Campaigns no longer show a full address, so a location
relationship was overkill. We wanted to make the API and
model simplier so are replacing location with just a raw
string.