### PR TITLE
Add get index for Distributors

### DIFF
--- a/app/controllers/distributors_controller.rb
+++ b/app/controllers/distributors_controller.rb
@@ -3,6 +3,11 @@
 class DistributorsController < ApplicationController
   before_action :set_distributor, only: %i[show update]
 
+  # GET /distributors
+  def index
+    json_response(Distributor.all)
+  end
+
   # POST /distributors
   def create
     json_response(Distributor.create!(create_params), :created)

--- a/spec/requests/distributors_request_spec.rb
+++ b/spec/requests/distributors_request_spec.rb
@@ -3,6 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe 'Distributors', type: :request do
+
+  describe 'GET /distributors' do
+    let!(:distributors) do
+      (1..10).map { create :distributor }
+    end
+
+    before { get "/distributors" }
+
+    it 'returns the distributor' do
+      expect(json.size).to eq distributors.size
+    end
+
+    it 'returns status code 200' do
+      expect(response).to have_http_status(200)
+    end
+  end
+
   describe 'GET /distributors/:id' do
     let!(:distributor) { create :distributor }
     before { get "/distributors/#{distributor_id}" }


### PR DESCRIPTION
We needed to add a get index endpoint for
Distributors so that whoever is creating a
campaign can get all Distributors to see
which Distributor they should relate their
new campaign to.