### PR TITLE
add non-profit's fee_id to payment intent

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -195,8 +195,8 @@ class ChargesController < ApplicationController
     # Creates a pending PaymentIntent. See webhooks_controller to see what
     # happens when the PaymentIntent is successful.
     
-    # Check for whether a campaign exits. If a campaign exists, check if the campaign has a non-profit associated with it. 
-    # If a non-profit exists, check if the non-profit has a fee ID. If so, the set fee ID equal to fee_id
+    # Check for whether a campaign exits. If a campaign exists, then check whether the campaign has a non-profit associated with it. 
+    # If a non-profit exists, then check whether the non-profit has a fee ID. If so, then set fee ID equal to fee_id
     fee_id = if @campaign && @campaign[:nonprofit_id] && Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id]
               Fee.find_by(id: Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id])[:id]
              end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -194,6 +194,13 @@ class ChargesController < ApplicationController
 
     # Creates a pending PaymentIntent. See webhooks_controller to see what
     # happens when the PaymentIntent is successful.
+    
+    # Check for whether a campaign exits. If a campaign exists, check if the campaign has a non-profit associated with it. 
+    # If a non-profit exists, check if the non-profit has a fee ID. If so, the set fee ID equal to fee_id
+    fee_id = if @campaign && @campaign[:nonprofit_id] && Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id]
+              Fee.find_by(id: Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id])[:id]
+             end
+
     PaymentIntent.create!(
       square_location_id: square_location_id,
       square_payment_id: payment[:id],
@@ -203,7 +210,8 @@ class ChargesController < ApplicationController
       recipient: recipient,
       campaign: @campaign,
       metadata: metadata,
-      project: Project.find_by(id: project_id)
+      project: Project.find_by(id: project_id),
+      fee_id: fee_id
     )
 
     api_response

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -194,12 +194,6 @@ class ChargesController < ApplicationController
 
     # Creates a pending PaymentIntent. See webhooks_controller to see what
     # happens when the PaymentIntent is successful.
-    
-    # Check for whether a campaign exits. If a campaign exists, then check whether the campaign has a non-profit associated with it. 
-    # If a non-profit exists, then check whether the non-profit has a fee ID. If so, then set fee ID equal to fee_id
-    fee_id = if @campaign && @campaign[:nonprofit_id] && Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id]
-              Fee.find_by(id: Nonprofit.find_by(id: @campaign[:nonprofit_id])[:fee_id])[:id]
-             end
 
     PaymentIntent.create!(
       square_location_id: square_location_id,
@@ -211,10 +205,18 @@ class ChargesController < ApplicationController
       campaign: @campaign,
       metadata: metadata,
       project: Project.find_by(id: project_id),
-      fee_id: fee_id
+      fee_id: get_nonprofit_fee_id
     )
 
     api_response
+  end
+
+  # Get the fee
+  def get_nonprofit_fee_id
+    nonprofit_id = @campaign[:nonprofit_id] if @campaign
+    nonprofit_fee_id = Nonprofit.find(nonprofit_id)[:fee_id] if nonprofit_id
+    
+    nonprofit_fee_id
   end
 
   def gift_a_meal?

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -114,10 +114,11 @@ class WebhooksController < ApplicationController
     end
 
     items = JSON.parse(payment_intent.line_items)
-    recipient = payment_intent.recipient
     is_donation = false
     save_payment_intent = false
-    items = items.reject { |item| item['type'] == 'fee' }
+
+    items.reject! { |item| item['item_type'] == 'transaction_fee' }
+
     items.each do |item_json|
       # TODO(jtmckibb): Add some tracking that tracks if it breaks somewhere
       # here

--- a/spec/factories/payment_intent.rb
+++ b/spec/factories/payment_intent.rb
@@ -29,4 +29,15 @@ FactoryBot.define do
       )
     end
   end
+
+  trait :with_transaction_fee do
+    line_items do
+      %(
+        [
+          {"amount": 1000, "seller_id": "43", "item_type": "donation"},
+          {"amount": 314, "seller_id": "43", "item_type": "transaction_fee"}
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
Updated the `charges_controller` so that the `fee_id` from a non-profit is included in a `payment_intent`.

Logic I used to determine the `fee_id` is:
- Is there a campaign?
- If so, is there a non-profit associated with that campaign?
- If so, is there a `fee_id` associated with that non-profit?
- If so, return the `fee_id`

If any of the questions above is "no", then don't return anything