### PR TITLE
add non-profit's fee_id to payment intent

### DIFF
--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -125,12 +125,12 @@ class ChargesController < ApplicationController
 
                     campaign
                   elsif charge_params[:campaign_id].present?
-                    Campaign.find_by(campaign_id: campaign_id)
+                    Campaign.find_by(id: charge_params[:campaign_id])
                   end
 
       amount = line_item['amount']
 
-      unless gift_a_meal? && @seller.cost_per_meal.present? && amount % @seller.cost_per_meal != 0
+      unless gift_a_meal? && @seller.present? && @seller.cost_per_meal.present? && amount % @seller.cost_per_meal != 0
         next
       end
 
@@ -155,7 +155,7 @@ class ChargesController < ApplicationController
     metadata:,
     project_id:
   )
-    square_location_id = if gift_a_meal? && @seller.non_profit_location_id.present?
+    square_location_id = if gift_a_meal? && @seller.present? && @seller.non_profit_location_id.present?
                            @seller.non_profit_location_id
                          elsif @project.present?
                            @project.square_location_id
@@ -217,7 +217,7 @@ class ChargesController < ApplicationController
 
     nonprofit_fee_id
   end
-  
+
   def gift_a_meal?
     @campaign.present?
   end

--- a/app/controllers/charges_controller.rb
+++ b/app/controllers/charges_controller.rb
@@ -203,12 +203,21 @@ class ChargesController < ApplicationController
       recipient: recipient,
       campaign: @campaign,
       metadata: metadata,
-      project: Project.find_by(id: project_id)
+      project: Project.find_by(id: project_id),
+      fee_id: get_nonprofit_fee_id
     )
 
     api_response
   end
 
+  # Get the fee
+  def get_nonprofit_fee_id
+    nonprofit_id = @campaign[:nonprofit_id] if @campaign
+    nonprofit_fee_id = Nonprofit.find(nonprofit_id)[:fee_id] if nonprofit_id
+
+    nonprofit_fee_id
+  end
+  
   def gift_a_meal?
     @campaign.present?
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -215,6 +215,8 @@ seller = Seller.find_by(seller_id: 'shunfa-bakery')
 contact = Contact.find_or_create_by!(name: 'Apex for Youth', email: 'distributor@apexforyouth.com')
 distributor = Distributor.create contact: contact, image_url: 'https://storage.googleapis.com/sendchinatownlove-assets/public/assets/apex-for-youth/apex-for-youth-logo.png', website_url: 'apexforyouth.com', name: 'Apex for Youth'
 location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborhood: 'Chinatown', state: 'NY', zip_code: '12345')
+nonprofit = Nonprofit.create(name: 'Non Profit', fee_id: Fee.first[:id])
+
 (0..20).each do |i|
   if i == 0
     Campaign.create(
@@ -223,6 +225,7 @@ location = Location.create(address1: '123 Mott St.', city: 'Zoo York', neighborh
       location: location,
       active: true,
       end_date: Time.now + 30.days,
+      nonprofit_id: nonprofit.id,
       gallery_image_urls: [
         "https://storage.googleapis.com/sendchinatownlove-assets/public/assets/general/campaign-default.png"
       ],

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 require 'rails_helper'
@@ -15,10 +16,10 @@ RSpec.describe ChargesController, type: :controller do
       it 'should create a payment_intent using the non_profit_location_id' do
         allow(SquareManager::PaymentCreator)
           .to receive(:call)
-          .with(payment_create_params(seller_non_prof, non_profit = true))
+          .with(create_payment_params(seller: seller_non_prof, seller_has_nonprofit: true))
           .and_return(mock_response)
 
-        response = post :create, params: charge_params(seller_non_prof, is_square = true), as: :json
+        response = post :create, params: create_charge_params(seller: seller_non_prof, is_square: true), as: :json
         expect(response.status).to eq 200
         expect(PaymentIntent.find_by(square_location_id: seller_non_prof.non_profit_location_id)).not_to eq nil
       end
@@ -28,12 +29,101 @@ RSpec.describe ChargesController, type: :controller do
       it 'should create a payment_intent using the square_location_id' do
         allow(SquareManager::PaymentCreator)
           .to receive(:call)
-          .with(payment_create_params(seller, non_profit = false))
+          .with(create_payment_params(seller: seller, seller_has_nonprofit: false))
           .and_return(mock_response)
 
-        response = post :create, params: charge_params(seller, is_square = true), as: :json
+        response = post :create, params: create_charge_params(seller: seller, is_square: true), as: :json
         expect(response.status).to eq 200
         expect(PaymentIntent.find_by(square_location_id: seller.square_location_id)).not_to eq nil
+      end
+    end
+  end
+
+  describe 'POST create with nonprofit fee' do      
+    let!(:mock_response) { MockApiResponseHelper::MockSquareApiResponse.new }
+    let!(:seller_id) { 21 }
+    let!(:fee_id) { 3 }
+    let!(:nonprofit_id) { 4 }
+    let!(:campaign_id) { 12 }
+    let!(:square_location_id) { 'L8' }
+    let!(:project_id) { 19 }
+
+    context 'when campaign has a nonprofit with a fee_id' do
+      it 'should create a payment_intent that has the campaign_id and fee_id' do
+        @seller = create(
+          :seller,
+          id: seller_id,
+          square_location_id: square_location_id
+        )
+        @fee = create(
+          :fee, 
+          id: fee_id,
+          active: true, 
+          multiplier: 0.1
+        )
+        @nonprofit = create(
+          :nonprofit,
+          id: nonprofit_id,
+          fee_id: @fee.id
+        )
+        @campaign = create(
+          :campaign,
+          id: campaign_id,
+          active: true,
+          seller_id: seller_id,
+          nonprofit_id: @nonprofit.id
+        )
+
+        payment_params = create_payment_params(seller: @seller, campaign: @campaign)
+        
+        allow(SquareManager::PaymentCreator)
+          .to receive(:call)
+          .with(payment_params)
+          .and_return(mock_response)
+
+        cparams = create_charge_params(seller: @seller, is_square: true, campaign: @campaign, is_distribution: false)
+        response = post :create, params: cparams, as: :json
+        payment_intent = PaymentIntent.find_by(campaign_id: campaign_id, fee_id: fee_id)
+        expect(payment_intent).to_not eq nil
+        expect(response.status).to eq 200
+      end
+    end
+
+    context 'when campaign has a project_id and a nonprofit with a fee_id' do
+      it 'should create a payment_intent that has the project_id, campaign_id and fee_id' do
+        @project = create(:project, id: project_id, square_location_id: square_location_id)
+        @fee = create(
+          :fee, 
+          id: fee_id,
+          active: true, 
+          multiplier: 0.1
+        )
+        @nonprofit = create(
+          :nonprofit,
+          id: nonprofit_id,
+          fee_id: @fee.id
+        )
+        @campaign = create(
+          :campaign,
+          id: campaign_id,
+          active: true,
+          seller_id: nil,
+          project_id: @project.id,
+          nonprofit_id: @nonprofit.id
+        )
+
+        payment_params = create_payment_params(campaign: @campaign, project: @project)
+
+        allow(SquareManager::PaymentCreator)
+          .to receive(:call)
+          .with(payment_params)
+          .and_return(mock_response)
+
+        cparams = create_charge_params(is_square: true, campaign: @campaign, is_distribution: false)
+        response = post :create, params: cparams, as: :json
+        payment_intent = PaymentIntent.find_by(campaign_id: campaign_id, project_id: project_id, fee_id: fee_id)
+        expect(payment_intent).to_not eq nil
+        expect(response.status).to eq 200
       end
     end
   end
@@ -41,40 +131,84 @@ RSpec.describe ChargesController, type: :controller do
   ###############
   ### Helpers ###
   ###############
-  def charge_params(seller, is_square = false)
+
+  def create_charge_params(seller: nil, is_square: false, campaign: nil, is_distribution: true)
+    seller_id = seller.seller_id if seller
+    campaign_id = campaign.id if campaign
+    project_id = campaign.project_id if campaign
+    line_items = create_line_items(project_id: project_id)
     params = {
-      seller_id: seller.seller_id,
+      seller_id: seller_id,
       line_items: line_items,
       email: 'cthulhu@rlyeh.com',
       is_square: is_square,
       name: 'Cthulhu',
       idempotency_key: '42',
       is_subscribed: true,
-      is_distribution: true
+      is_distribution: is_distribution,
+      campaign_id: campaign_id,
+      project_id: project_id
     }
-
     params.merge! nonce: 'cnon:card-nonce-ok' if is_square
     params
   end
 
-  def line_items
-    [{
-      'amount' => 50,
-      'currency' => 'usd',
-      'quantity' => 1,
-      'item_type' => 'donation'
-    }]
+  def default_line_items 
+    { 
+      'amount' => 50, 
+      'currency' => 'usd', 
+      'quantity' => 1, 
+      'item_type' => 'donation' 
+    }
   end
 
-  def payment_create_params(seller, non_profit)
-    cparams = charge_params(seller, is_square = true)
-    lid = non_profit ? seller.non_profit_location_id : seller.square_location_id
+  # TODO (billy-yuan): Update create_line_items so that transaction fees can be
+  # included as a separate line_items group
+  def create_line_items(extra_line_items = {})
+    line_items = default_line_items
+    extra_line_items.each do |extra_line_item, value|
+      if value
+        line_items[extra_line_item] = value
+      end
+    end
+    [line_items]
+  end
+
+  def create_payment_params(
+    seller: nil, 
+    seller_has_nonprofit: false, 
+    campaign: nil, 
+    project: nil,
+    line_items: nil
+  )
+    campaign_id = campaign.id if campaign
+    project_id = campaign.project_id if campaign
+    location_id = get_location_id(
+                    project: project, 
+                    seller: seller, 
+                    seller_has_nonprofit: seller_has_nonprofit
+                  )
+    cparams = create_charge_params(
+                is_square: true, 
+                campaign: campaign
+              )
+    line_items = create_line_items(project_id: project_id)
 
     {
       nonce: cparams[:nonce],
       amount: line_items.first['amount'],
       email: cparams[:email],
-      location_id: lid
+      location_id: location_id
     }
+  end
+
+  def get_location_id(project: nil, seller: nil, seller_has_nonprofit: false)
+    if project
+      project.square_location_id
+    elsif seller_has_nonprofit
+      seller.non_profit_location_id
+    else
+      seller.square_location_id
+    end
   end
 end

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -81,7 +81,12 @@ RSpec.describe ChargesController, type: :controller do
           .with(payment_params)
           .and_return(mock_response)
 
-        cparams = create_charge_params(seller: @seller, is_square: true, campaign: @campaign, is_distribution: false)
+        cparams = create_charge_params(
+                    seller: @seller, 
+                    is_square: true, 
+                    campaign: @campaign, 
+                    is_distribution: false
+                  )
         response = post :create, params: cparams, as: :json
         payment_intent = PaymentIntent.find_by(campaign_id: campaign_id, fee_id: fee_id)
         expect(payment_intent).to_not eq nil
@@ -121,7 +126,11 @@ RSpec.describe ChargesController, type: :controller do
 
         cparams = create_charge_params(is_square: true, campaign: @campaign, is_distribution: false)
         response = post :create, params: cparams, as: :json
-        payment_intent = PaymentIntent.find_by(campaign_id: campaign_id, project_id: project_id, fee_id: fee_id)
+        payment_intent = PaymentIntent.find_by(
+                          campaign_id: campaign_id, 
+                          project_id: project_id, 
+                          fee_id: fee_id
+                         ) 
         expect(payment_intent).to_not eq nil
         expect(response.status).to eq 200
       end

--- a/spec/controllers/charges_controller_spec.rb
+++ b/spec/controllers/charges_controller_spec.rb
@@ -50,31 +50,31 @@ RSpec.describe ChargesController, type: :controller do
 
     context 'when campaign has a nonprofit with a fee_id' do
       it 'should create a payment_intent that has the campaign_id and fee_id' do
-        @seller = create(
+        seller = create(
           :seller,
           id: seller_id,
           square_location_id: square_location_id
         )
-        @fee = create(
+        fee = create(
           :fee, 
           id: fee_id,
           active: true, 
           multiplier: 0.1
         )
-        @nonprofit = create(
+        nonprofit = create(
           :nonprofit,
           id: nonprofit_id,
-          fee_id: @fee.id
+          fee_id: fee.id
         )
-        @campaign = create(
+        campaign = create(
           :campaign,
           id: campaign_id,
           active: true,
           seller_id: seller_id,
-          nonprofit_id: @nonprofit.id
+          nonprofit_id: nonprofit.id
         )
 
-        payment_params = create_payment_params(seller: @seller, campaign: @campaign)
+        payment_params = create_payment_params(seller: seller, campaign: campaign)
         
         allow(SquareManager::PaymentCreator)
           .to receive(:call)
@@ -82,9 +82,9 @@ RSpec.describe ChargesController, type: :controller do
           .and_return(mock_response)
 
         cparams = create_charge_params(
-                    seller: @seller, 
+                    seller: seller, 
                     is_square: true, 
-                    campaign: @campaign, 
+                    campaign: campaign, 
                     is_distribution: false
                   )
         response = post :create, params: cparams, as: :json
@@ -96,35 +96,35 @@ RSpec.describe ChargesController, type: :controller do
 
     context 'when campaign has a project_id and a nonprofit with a fee_id' do
       it 'should create a payment_intent that has the project_id, campaign_id and fee_id' do
-        @project = create(:project, id: project_id, square_location_id: square_location_id)
-        @fee = create(
+        project = create(:project, id: project_id, square_location_id: square_location_id)
+        fee = create(
           :fee, 
           id: fee_id,
           active: true, 
           multiplier: 0.1
         )
-        @nonprofit = create(
+        nonprofit = create(
           :nonprofit,
           id: nonprofit_id,
-          fee_id: @fee.id
+          fee_id: fee.id
         )
-        @campaign = create(
+        campaign = create(
           :campaign,
           id: campaign_id,
           active: true,
           seller_id: nil,
-          project_id: @project.id,
-          nonprofit_id: @nonprofit.id
+          project_id: project.id,
+          nonprofit_id: nonprofit.id
         )
 
-        payment_params = create_payment_params(campaign: @campaign, project: @project)
+        payment_params = create_payment_params(campaign: campaign, project: project)
 
         allow(SquareManager::PaymentCreator)
           .to receive(:call)
           .with(payment_params)
           .and_return(mock_response)
 
-        cparams = create_charge_params(is_square: true, campaign: @campaign, is_distribution: false)
+        cparams = create_charge_params(is_square: true, campaign: campaign, is_distribution: false)
         response = post :create, params: cparams, as: :json
         payment_intent = PaymentIntent.find_by(
                           campaign_id: campaign_id, 


### PR DESCRIPTION
There was a rebase issue in my previous PR, so I'm just incorporating comments from the [previous PR](https://github.com/sendchinatownlove/ruby/pull/314):

**This PR will fix the following issues in the `charges_controller`:**
1. Lines 206-220: **The `fee_id` of nonprofits will now be passed when a payment intent is created** (same change as the previous PR above). Test has also been created for this. 
2. Line 128,133, and 158: **Payment intents for campaigns that don't have a seller** (i.e. multi-seller GAM) **can now be created.**

**Tests created**
1.  When a campaign has a nonprofit with a fee_id, it should create a payment_intent that has the campaign_id and fee_id
2. When a campaign has a project_id and a nonprofit with a fee_id, it should create a payment_intent that has the project_id, campaign_id and fee_id

**Notes**
1. The chunk of this PR is from the `charges_controller_spec`. I had to refactor the code a bit so that I could add my 2 tests.
2. Removing `is_distribution` should be done in a separate PR since some tests may have to be edited, and the logic in the charges controller will also have to be updated.