### PR TITLE
Remove fees amount raised

### DIFF
--- a/spec/factories/payment_intent.rb
+++ b/spec/factories/payment_intent.rb
@@ -40,4 +40,15 @@ FactoryBot.define do
       )
     end
   end
+
+  trait :with_transaction_fee_project do
+    line_items do
+      %(
+        [
+          {"amount": 1000, "item_type": "donation", "project_id": 3, "quantity": 1},
+          {"amount": 314, "item_type": "transaction_fee", "project_id": 3, "quantity": 1}
+        ]
+      )
+    end
+  end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -158,6 +158,22 @@ RSpec.describe Campaign, type: :model do
     end
   end
 
+  context 'with amount raised for mega gam campaigns with transaction fees' do
+    let!(:campaign) { create(:campaign, :with_sellers_distributors, :with_project, seller: nil) }
+    subject do
+      # Expect these 2 to be counted. :with_line_items adds line items of value 600.
+      payment_intent_1 = create(:payment_intent, :with_line_items, :with_transaction_fee_project, campaign: campaign, successful: true)
+      payment_intent_2 = create(:payment_intent, :with_line_items, :with_transaction_fee_project, campaign: campaign, successful: true)
+      # Do not expect this one to be counted since it's not successful.
+      payment_intent_3 = create(:payment_intent, :with_line_items, :with_transaction_fee_project, campaign: campaign, successful: false)
+    end
+      
+    it 'returns payment intent amounts' do
+      subject
+      expect(campaign.amount_raised).to eq 2000
+    end
+  end
+
   context 'with seller distributor pairs' do
     let!(:campaign) { create(:campaign, :with_sellers_distributors) }
 


### PR DESCRIPTION
Removed transaction fees when calculating mega gams (i.e. campaign w/ a project id)

Line item of 1000 donation amount and 112 fee
![image](https://user-images.githubusercontent.com/20375084/103847777-f6aba200-506e-11eb-9e65-d7ee6e3abd40.png)

Amount raised of 1000
![image](https://user-images.githubusercontent.com/20375084/103847848-117e1680-506f-11eb-9821-dcf6e5e79db3.png)

