### PR TITLE
added callback to payment intent to make campaign inactive if goal is met

### DIFF
--- a/spec/models/payment_intent_spec.rb
+++ b/spec/models/payment_intent_spec.rb
@@ -98,4 +98,20 @@ RSpec.describe PaymentIntent, type: :model do
       )
     end
   end
+
+  context 'turn off campaign if goal is reached' do
+    it "turns the campaign inactive if the campaign is associated with a project " do
+      project = create(:project)
+      campaign = create(:campaign, active: true, project_id: project.id, target_amount: 10000, seller_id: nil)
+      expect(campaign.active).to eq(true)
+
+      line_items =  '[
+        { "amount": 10000, "project_id": 1, "item_type": "donation" },
+        { "amount": 314, "project_id": 1, "item_type": "transaction_fee" }
+      ]'
+      payment_intent = create(:payment_intent, line_items: line_items, campaign_id: campaign.id, project_id: project.id, successful: true)
+      
+      expect(Campaign.find(campaign.id).active).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Added a callback to the `PaymentIntent` model that makes the campaign inactive if goal is met after a payment intent is created.

I haven't checked to see whether this works for normal campaigns since the logic is using the PaymentIntent model.

Also open to using a different approach for checking whether a campaign has met its goal