### PR TITLE
add redemption association and dependent destroy

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -15,4 +15,6 @@ class Reward < ApplicationRecord
   validates_presence_of :image_url
   validates_presence_of :name
   validates_presence_of :total_value
+
+  has_many :redemptions, dependent: :destroy
 end

--- a/spec/models/reward_spec.rb
+++ b/spec/models/reward_spec.rb
@@ -17,4 +17,5 @@ RSpec.describe Reward, type: :model do
   it { should validate_presence_of(:total_value) }
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:image_url) }
+  it { should have_many(:redemptions) }
 end


### PR DESCRIPTION
in order to destroy a reward, we need to also destroy all redemptions pointing toward it

this is so we can delete the grand prize reward so it doesnt show up 