### PR TITLE
Unredeem Receipts on Redemption Deletion

### DIFF
--- a/app/models/redemption.rb
+++ b/app/models/redemption.rb
@@ -19,6 +19,18 @@
 #  fk_rails_...  (reward_id => rewards.id)
 #
 class Redemption < ApplicationRecord
+  before_destroy :unredeem_receipts
   belongs_to :reward
   belongs_to :contact
+
+  has_many :crawl_receipts
+
+  private
+
+  def unredeem_receipts
+    CrawlReceipt.where(redemption_id: self.id).each do |receipt|
+      receipt.update_attribute(:redemption_id, nil)
+      receipt.save!
+    end
+  end
 end

--- a/spec/models/redemption_spec.rb
+++ b/spec/models/redemption_spec.rb
@@ -23,4 +23,21 @@ require 'rails_helper'
 RSpec.describe Redemption, type: :model do
   it { should belong_to(:contact) }
   it { should belong_to(:reward) }
+  it { should have_many(:crawl_receipts) }
+
+  describe '#unredeem_receipts' do
+    let!(:contact) { create(:contact) }
+    let!(:reward) { create(:reward) }
+    let!(:redemption) { create(:redemption, contact: contact, reward: reward) }
+    let!(:crawl_receipt1) { create(:crawl_receipt, :with_payment_intent, redemption: redemption) }
+    let!(:crawl_receipt2) { create(:crawl_receipt, :with_payment_intent, redemption: redemption) }
+    let!(:crawl_receipt3) { create(:crawl_receipt, :with_payment_intent, redemption: redemption) }
+
+    it 'unredeems the receipts when the redemption is destroyed' do
+      redemption.destroy!
+      expect(crawl_receipt1.reload.redemption_id).to eq(nil)
+      expect(crawl_receipt2.reload.redemption_id).to eq(nil)
+      expect(crawl_receipt3.reload.redemption_id).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
In order to destroy the grand prize reward, we need to destroy the redemptions associated with the reward. However, we can't destroy a redemption with associated receipts, so this PR allows us to 'unredeem' crawl_receipts when the associated redemption is destroyed.