### PR TITLE
Remove min amount for crawl receipt

### DIFF
--- a/app/models/crawl_receipt.rb
+++ b/app/models/crawl_receipt.rb
@@ -38,8 +38,6 @@ class CrawlReceipt < ApplicationRecord
   belongs_to :participating_seller, optional: true
   belongs_to :payment_intent, optional: true
 
-  CRAWL_RECEIPT_MIN_AMOUNT = 10_00
-
   def has_participating_seller_xor_payment_indent?
     unless participating_seller.present? ^ payment_intent.present?
       errors.add('Participating Seller or Payment Intent must exist, but not both')

--- a/app/services/webhook_manager/crawl_receipt_creator.rb
+++ b/app/services/webhook_manager/crawl_receipt_creator.rb
@@ -10,7 +10,7 @@ module WebhookManager
     end
 
     def call
-      if Time.now <= Time.find_zone('EST').local(2021,3,1) && Time.now >= Time.find_zone('EST').local(2021,2,1) && @amount >= CrawlReceipt::CRAWL_RECEIPT_MIN_AMOUNT
+      if Time.now <= Time.find_zone('EST').local(2021,3,1) && Time.now >= Time.find_zone('EST').local(2021,2,1)
         CrawlReceipt.create!(amount: amount, payment_intent_id: payment_intent_id, contact_id: contact_id, receipt_url: ' ')
       end
     end

--- a/spec/requests/webhooks_spec.rb
+++ b/spec/requests/webhooks_spec.rb
@@ -185,13 +185,13 @@ RSpec.describe 'Webhooks API', type: :request do
         end
       end
 
-      context 'with too small of a donation' do
+      context 'with a small donation' do
         let(:amount) { 500 }
         let(:item_type) { 'donation' }
         let(:seller_id) { seller1.seller_id }
 
-        it 'does not create a crawl receipt' do
-          expect(CrawlReceipt.where(contact_id: payment_intent.purchaser.id).count).to be(0)
+        it 'creates a crawl receipt' do
+          expect(CrawlReceipt.where(contact_id: payment_intent.purchaser.id).count).to be(1)
          end
       end
 


### PR DESCRIPTION
We found that having a min amount for the food
crawl was difficult for some merchants. We
decided to remove it altogether and in order to
be consistent across the board we want to also
remove it for donations.