### PR TITLE
LNY crawl redemption email rake task

### DIFF
--- a/app/services/email_manager/lny_crawl_redemption_sender.rb
+++ b/app/services/email_manager/lny_crawl_redemption_sender.rb
@@ -21,7 +21,7 @@ module EmailManager
         </p>
 
         <p>
-          • Number of Raffle Tickets Entered: #{number_of_raffle_tickets_entered}
+          &emsp;• Number of Raffle Tickets Entered: #{number_of_raffle_tickets_entered}
         </p>
       "
       end

--- a/app/services/email_manager/lny_crawl_redemption_sender.rb
+++ b/app/services/email_manager/lny_crawl_redemption_sender.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module EmailManager
+  class LnyCrawlRedemptionSender < BaseService
+    def initialize(params)
+      @contact_id = params[:contact_id]
+      @contact = Contact.find(@contact_id)
+      @email = @contact.email
+    end
+
+    def call
+      entry_details = "<p><b>Giveaway Entry Details</b></p>"
+      redemptions = Redemption.where(contact: @contact)
+      redemptions.uniq.each do |redemption|
+        reward = redemption.reward
+        selected_basket = reward.name
+        number_of_raffle_tickets_entered = redemptions.where(reward: reward).count
+        entry_details += "
+        <p>
+          • Basket Selected: #{selected_basket}
+        </p>
+
+        <p>
+          • Number of Raffle Tickets Entered: #{number_of_raffle_tickets_entered}
+        </p>
+      "
+      end
+
+      total_number_of_tickets = redemptions.count
+      entry_details += "<br><p>
+      Total number of tickets entered to date: #{total_number_of_tickets}
+      </p>"
+
+      html = <<~EOF
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+          </head>
+          <body>
+            <p>
+            Thank you for supporting Asian-owned small businesses this Lunar New Year! These struggling merchants are the backbone of New York City and your generosity will help keep them afloat.
+            </p>
+
+            <br>
+
+            <p>
+              #{entry_details}
+            </p>
+
+            <p>
+              Winners will be drawn and contacted at the end of the month. In the meantime, please feel free to reach out to us with any questions. Thanks again for sharing your love with those who need it most.
+            </p>
+          </body>
+        </html>
+      EOF
+
+      EmailManager::Sender.send_receipt(
+        to: @email,
+        html: html,
+        subject: '🌟 Lunar New Year Crawl Giveaway Entry Confirmation'
+      )
+    rescue StandardError
+      Rails.logger.error 'Weekly Giveaway Entries Email errored out' \
+              "email: #{@email}"
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -475,6 +475,10 @@ end
   {
     contact_id: lny_contact1.id,
     reward_id: Reward.first.id
+  },
+  {
+    contact_id: lny_contact1.id,
+    reward_id: Reward.last.id
   }
 ].each do |attributes|
   Redemption.find_or_create_by(attributes)

--- a/lib/tasks/email_lny_crawl_redemptions.rake
+++ b/lib/tasks/email_lny_crawl_redemptions.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+namespace :emailer do
+  desc 'Emails every person with redemptions all of their redemptions'
+  task email_all_lny_crawl_redemptions: :environment do
+    desc 'send emails'
+
+    Redemption.all.map(&:contact_id).uniq.each do |contact_id|
+      contact = Contact.find(contact_id)
+      send_email contact: contact
+    end
+  end
+
+  desc 'Emails customer their LNY crawl redemption information'
+  task :email_lny_crawl_redemptions, %i[contact_id] => [:environment] do |_task, args|
+    send_email contact: Contact.find(args.contact_id)
+  end
+
+  def send_email(contact:)
+    if Redemption.where(contact: contact).present?
+      EmailManager::LnyCrawlRedemptionSender.call(contact_id: contact.id)
+    end
+  end
+end


### PR DESCRIPTION
Email sent locally:

<img width="1527" alt="Screen Shot 2021-02-21 at 9 32 58 PM" src="https://user-images.githubusercontent.com/22249373/108667483-29c6bb00-748e-11eb-918a-013c79036e46.png">

Copy: https://docs.google.com/document/d/1QUFaA3swXXa1XUoUAd_nIttvgFHo_FCdULwuOIYFPZ4/edit

We plan to use the rake task to retroactively send out email confirmations for the (as of 2/21) 25 contacts who have redeemed 28 entries. 

This is [followed up by a PR](https://github.com/sendchinatownlove/ruby/pull/348) that will automate this process (with changes to the email body)