### PR TITLE
LNY crawl automatically send emails

### DIFF
--- a/app/controllers/redemptions_controller.rb
+++ b/app/controllers/redemptions_controller.rb
@@ -20,6 +20,8 @@ class RedemptionsController < ApplicationController
         receipts_to_redeem[i].update!(redemption: @redemption)
       end
 
+      EmailManager::LnyCrawlRedemptionSender.call(contact_id: @contact.id, redemption_id: @redemption.id)
+
       json_response(@redemption, :created)
     end
   end

--- a/app/services/email_manager/lny_crawl_redemption_sender.rb
+++ b/app/services/email_manager/lny_crawl_redemption_sender.rb
@@ -5,28 +5,28 @@ module EmailManager
     def initialize(params)
       @contact_id = params[:contact_id]
       @contact = Contact.find(@contact_id)
+      @redemption_id = params[:redemption_id]
+      @redemption = Redemption.find(@redemption_id)
       @email = @contact.email
     end
 
     def call
       entry_details = "<p><b>Giveaway Entry Details</b></p>"
-      redemptions = Redemption.where(contact: @contact)
-      redemptions.uniq.each do |redemption|
-        reward = redemption.reward
-        selected_basket = reward.name
-        number_of_raffle_tickets_entered = redemptions.where(reward: reward).count
-        entry_details += "
-        <p>
-          • Basket Selected: #{selected_basket}
-        </p>
+      reward = @redemption.reward
+      selected_basket = reward.name
+      number_of_raffle_tickets_entered = 1
 
-        <p>
-          &emsp;• Number of Raffle Tickets Entered: #{number_of_raffle_tickets_entered}
-        </p>
+      entry_details += "
+      <p>
+        • Basket Selected: #{selected_basket}
+      </p>
+
+      <p>
+        &emsp;• Number of Raffle Tickets Entered: #{number_of_raffle_tickets_entered}
+      </p>
       "
-      end
 
-      total_number_of_tickets = redemptions.count
+      total_number_of_tickets = Redemption.where(contact: @contact).count
       entry_details += "<br><p>
       Total number of tickets entered to date: #{total_number_of_tickets}
       </p>"


### PR DESCRIPTION
Follow-up of: https://github.com/sendchinatownlove/ruby/pull/347

This will send an email whenever a new redemption is created. The language of the body is modified.

@nanxiy, right now, this will send an email for *each* redemption that is made, so if a user makes 2 redemptions at the same time, they'll receive 2 separate emails. It will be more difficult to change this to send 1 bulk email, and I don't think it will be worth it since only 3 people currently have made more than 1 redemption (likely at different times)

I'm thinking of changing the copy to say something along the lines of 'You have made an entry into [Giveaway Basket]!' instead of showing the count of entries

Old email body for reference:
<img width="1527" alt="Screen Shot 2021-02-21 at 9 32 58 PM" src="https://user-images.githubusercontent.com/22249373/108668264-bd4cbb80-748f-11eb-9a91-dbdd09363676.png">


Note: This was checked out from the previous PR with the rake task, and will be rebased once that is merged in. Please ignore the first 2 commits!