### PR TITLE
Fixing missing http prefix in voucher links in emails

### DIFF
--- a/app/services/email_manager/gift_card_receipt_sender.rb
+++ b/app/services/email_manager/gift_card_receipt_sender.rb
@@ -14,7 +14,7 @@ module EmailManager
     # rubocop:disable Layout/LineLength
     def call
       amount_string = EmailManager::Sender.format_amount(amount: amount)
-      gift_card_url = 'merchant.sendchinatownlove.com/voucher/' + gift_card_detail.gift_card_id
+      gift_card_url = 'https://merchant.sendchinatownlove.com/voucher/' + gift_card_detail.gift_card_id
       html = '<!DOCTYPE html>' \
            '<html>' \
            '<head>' \


### PR DESCRIPTION
- This was causing a bug in the iOS native mail app where links were unclickable 🤷